### PR TITLE
Clang

### DIFF
--- a/offline/packages/Prototype3/configure.ac
+++ b/offline/packages/Prototype3/configure.ac
@@ -5,12 +5,14 @@ AM_INIT_AUTOMAKE
 AC_PROG_CXX(g++)
 LT_INIT([disable-static])
 
-dnl   no point in suppressing warnings people should
-dnl   at least see them, so here we go for g++: -Wall
-dnl   make warnings fatal errors: -Werror
-if test $ac_cv_prog_gxx = yes; then
-   CXXFLAGS="$CXXFLAGS -Wall"
-fi
+case $CXX in
+ clang++)
+  CXXFLAGS="$CXXFLAGS -Wall -Wno-deprecated-declarations -Werror"
+ ;;
+ g++)
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
+ ;;
+esac
 
 dnl test for root 6
 if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then

--- a/offline/packages/Prototype4/configure.ac
+++ b/offline/packages/Prototype4/configure.ac
@@ -5,12 +5,14 @@ AM_INIT_AUTOMAKE
 AC_PROG_CXX(g++)
 LT_INIT([disable-static])
 
-dnl   no point in suppressing warnings people should
-dnl   at least see them, so here we go for g++: -Wall
-dnl   make warnings fatal errors: -Werror
-if test $ac_cv_prog_gxx = yes; then
-   CXXFLAGS="$CXXFLAGS -Wall"
-fi
+case $CXX in
+ clang++)
+  CXXFLAGS="$CXXFLAGS -Wall -Wno-deprecated-declarations -Werror"
+ ;;
+ g++)
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
+ ;;
+esac
 
 dnl test for root 6
 if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then


### PR DESCRIPTION
This PR disables the  deprecated warning when using clang to make this compile with clang. The warning is from a boost header as far as I can see - not sure if we can do anything about this other than disabling the warning