### PR TITLE
fix warning, use cflags from geant4-config for GEANT4 MT

### DIFF
--- a/simulation/g4simulation/g4caloprototype/Makefile.am
+++ b/simulation/g4simulation/g4caloprototype/Makefile.am
@@ -5,6 +5,9 @@ lib_LTLIBRARIES = \
     libg4caloprototype_io.la \
     libg4caloprototype.la
 
+#AM_CXXFLAGS = `geant4-config --cflags | sed s/-Woverloaded-virtual// | sed s/-W\ // | sed s/-Wshadow//`
+AM_CXXFLAGS = `geant4-config --cflags | sed s/-Woverloaded-virtual// | sed s/-W\ // | sed s/-Wshadow// `
+
 AM_CPPFLAGS = \
     -DCGAL_DISABLE_ROUNDING_MATH_CHECK \
     -I$(includedir) \

--- a/simulation/g4simulation/g4caloprototype/PHG4PrototypeHcalDefs.h
+++ b/simulation/g4simulation/g4caloprototype/PHG4PrototypeHcalDefs.h
@@ -9,6 +9,6 @@ namespace PHG4PrototypeHcalDefs
 {
   // parameter names used in lookups by other modules
   static const std::string scipertwr = "n_scinti_plates_per_tower";
-};
+}
 
 #endif


### PR DESCRIPTION
for use of G4cout one needs to link against G4 which with the MT version of G4 needs to use geant4-config --cflags added to the CXXFLAGS