### PR TITLE
Enable Volume hierarchy in macro

### DIFF
--- a/offline/packages/Prototype2/GenericUnpackPRDF.cc
+++ b/offline/packages/Prototype2/GenericUnpackPRDF.cc
@@ -3,8 +3,8 @@
 #include "PROTOTYPE2_FEM.h"
 #include "RawTower_Prototype2.h"
 
+#include <calobase/RawTower.h>           // for RawTower
 #include <calobase/RawTowerDefs.h>  // for NONE
-
 #include <calobase/RawTowerContainer.h>
 
 #include <fun4all/Fun4AllBase.h>  // for Fun4AllBase::VERBOSITY_SOME

--- a/offline/packages/Prototype2/GenericUnpackPRDF.cc
+++ b/offline/packages/Prototype2/GenericUnpackPRDF.cc
@@ -3,9 +3,9 @@
 #include "PROTOTYPE2_FEM.h"
 #include "RawTower_Prototype2.h"
 
-#include <calobase/RawTower.h>           // for RawTower
-#include <calobase/RawTowerDefs.h>  // for NONE
+#include <calobase/RawTower.h>  // for RawTower
 #include <calobase/RawTowerContainer.h>
+#include <calobase/RawTowerDefs.h>  // for NONE
 
 #include <fun4all/Fun4AllBase.h>  // for Fun4AllBase::VERBOSITY_SOME
 #include <fun4all/Fun4AllReturnCodes.h>
@@ -69,7 +69,7 @@ int GenericUnpackPRDF::process_event(PHCompositeNode *topNode)
 
     if (packet_list.find(packet_id) == packet_list.end())
     {
-      packet_list[packet_id] =_event->getPacket(packet_id);
+      packet_list[packet_id] = _event->getPacket(packet_id);
     }
 
     Packet *packet = packet_list[packet_id];

--- a/offline/packages/Prototype2/TempInfoUnpackPRDF.cc
+++ b/offline/packages/Prototype2/TempInfoUnpackPRDF.cc
@@ -7,7 +7,9 @@
 #include <calobase/RawTowerContainer.h>
 #include <calobase/RawTowerDefs.h>  // for CEMC, HCALIN, HCALOUT
 
+#include <fun4all/Fun4AllBase.h>         // for Fun4AllBase::VERBOSITY_SOME
 #include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/SubsysReco.h>          // for SubsysReco
 
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>    // for PHIODataNode

--- a/offline/packages/Prototype2/TempInfoUnpackPRDF.cc
+++ b/offline/packages/Prototype2/TempInfoUnpackPRDF.cc
@@ -7,9 +7,9 @@
 #include <calobase/RawTowerContainer.h>
 #include <calobase/RawTowerDefs.h>  // for CEMC, HCALIN, HCALOUT
 
-#include <fun4all/Fun4AllBase.h>         // for Fun4AllBase::VERBOSITY_SOME
+#include <fun4all/Fun4AllBase.h>  // for Fun4AllBase::VERBOSITY_SOME
 #include <fun4all/Fun4AllReturnCodes.h>
-#include <fun4all/SubsysReco.h>          // for SubsysReco
+#include <fun4all/SubsysReco.h>  // for SubsysReco
 
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>    // for PHIODataNode

--- a/offline/packages/Prototype4/CaloCalibration.cc
+++ b/offline/packages/Prototype4/CaloCalibration.cc
@@ -22,10 +22,10 @@
 #include <boost/format.hpp>
 
 #include <cassert>
-#include <climits>  // for numeric_limits
 #include <cmath>    // for NAN, isnan
 #include <cstdlib>  // for exit
 #include <iostream>
+#include <limits>  // for numeric_limits
 #include <map>        // for map, _Rb_tree_iter...
 #include <stdexcept>  // for runtime_error
 #include <string>

--- a/offline/packages/Prototype4/CaloCalibration.cc
+++ b/offline/packages/Prototype4/CaloCalibration.cc
@@ -25,7 +25,7 @@
 #include <cmath>    // for NAN, isnan
 #include <cstdlib>  // for exit
 #include <iostream>
-#include <limits>  // for numeric_limits
+#include <limits>     // for numeric_limits
 #include <map>        // for map, _Rb_tree_iter...
 #include <stdexcept>  // for runtime_error
 #include <string>

--- a/simulation/g4simulation/g4caloprototype/PHG4HcalPrototypeDetector.cc
+++ b/simulation/g4simulation/g4caloprototype/PHG4HcalPrototypeDetector.cc
@@ -7,27 +7,27 @@
 
 #include "PHG4HcalPrototypeDetectorMessenger.h"  // for PHG4HcalPrototypeDet...
 
-#include <g4main/PHG4Detector.h>                 // for PHG4Detector
+#include <g4main/PHG4Detector.h>  // for PHG4Detector
 
-#include <Geant4/G4Material.hh>
-#include <Geant4/G4LogicalVolume.hh>
-#include <Geant4/G4PVPlacement.hh>
 #include <Geant4/G4Box.hh>
-#include <Geant4/G4UnionSolid.hh>
-#include <Geant4/G4Trap.hh>
-#include <Geant4/G4VisAttributes.hh>
 #include <Geant4/G4Colour.hh>
+#include <Geant4/G4LogicalVolume.hh>
+#include <Geant4/G4Material.hh>
 #include <Geant4/G4NistManager.hh>
-#include <Geant4/G4RotationMatrix.hh>            // for G4RotationMatrix
+#include <Geant4/G4PVPlacement.hh>
+#include <Geant4/G4RotationMatrix.hh>  // for G4RotationMatrix
 #include <Geant4/G4RunManager.hh>
-#include <Geant4/G4String.hh>                    // for G4String
-#include <Geant4/G4SystemOfUnits.hh>             // for cm, mm, deg, rad
-#include <Geant4/G4ThreeVector.hh>               // for G4ThreeVector
-#include <Geant4/G4Transform3D.hh>               // for G4Transform3D
-#include <Geant4/G4Types.hh>                     // for G4double, G4int, G4bool
-#include <Geant4/G4ios.hh>                       // for G4cout, G4endl
+#include <Geant4/G4String.hh>         // for G4String
+#include <Geant4/G4SystemOfUnits.hh>  // for cm, mm, deg, rad
+#include <Geant4/G4ThreeVector.hh>    // for G4ThreeVector
+#include <Geant4/G4Transform3D.hh>    // for G4Transform3D
+#include <Geant4/G4Trap.hh>
+#include <Geant4/G4Types.hh>  // for G4double, G4int, G4bool
+#include <Geant4/G4UnionSolid.hh>
+#include <Geant4/G4VisAttributes.hh>
+#include <Geant4/G4ios.hh>  // for G4cout, G4endl
 
-#include <cmath>                                // for cos, sin, M_PI, asin
+#include <cmath>  // for cos, sin, M_PI, asin
 #include <sstream>
 
 class PHCompositeNode;
@@ -36,177 +36,181 @@ using namespace std;
 
 // static double no_overlap = 0.00015 * cm; // added safety margin against overlaps by using same boundary between volumes
 
-PHG4HcalPrototypeDetector::PHG4HcalPrototypeDetector(PHG4Subsystem* subsys, PHCompositeNode *Node, const std::string &dnam, const int lyr  ):
-  PHG4Detector(subsys, Node, dnam),
-  nScint360(15),  // This is legacy variable in case one wants to build a cylindrical calorimeter 
-  nHcal1Layers(16),
-  nHcal2Layers(nHcal1Layers),
-  hcal2ScintSizeX(2.54*26.1*cm),      // from Don's drawing
-  hcal2ScintSizeY(0.85*cm),           // Changed from 8.0cm to 8.5cm following   
-  hcal2ScintSizeZ(2.54*29.53*cm),     // from Don's drawing
-  hcal1ScintSizeX(2.54*12.43*cm),     // from Don's drawing
-  hcal1ScintSizeY(0.85*cm),           // Changed from 8.0cm to 8.5cm following  
-  hcal1ScintSizeZ(2.54*17.1*cm),      // from Don's drawing
-  hcal1TiltAngle(0.27),
-  hcal2TiltAngle(0.14),
-  hcal1DPhi(0.27),   // calculated based on Don's drawing.  (twopi/16.0);
-  hcal2DPhi(0.288),  // calculated based on Don's drawing.  (twopi/16.0);
-  hcal1RadiusIn(1855*mm),
-  hcal2RadiusIn(hcal1RadiusIn + hcal1ScintSizeX),
+PHG4HcalPrototypeDetector::PHG4HcalPrototypeDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, const std::string& dnam, const int lyr)
+  : PHG4Detector(subsys, Node, dnam)
+  , nScint360(15)
+  ,  // This is legacy variable in case one wants to build a cylindrical calorimeter
+  nHcal1Layers(16)
+  , nHcal2Layers(nHcal1Layers)
+  , hcal2ScintSizeX(2.54 * 26.1 * cm)
+  ,  // from Don's drawing
+  hcal2ScintSizeY(0.85 * cm)
+  ,  // Changed from 8.0cm to 8.5cm following
+  hcal2ScintSizeZ(2.54 * 29.53 * cm)
+  ,  // from Don's drawing
+  hcal1ScintSizeX(2.54 * 12.43 * cm)
+  ,  // from Don's drawing
+  hcal1ScintSizeY(0.85 * cm)
+  ,  // Changed from 8.0cm to 8.5cm following
+  hcal1ScintSizeZ(2.54 * 17.1 * cm)
+  ,  // from Don's drawing
+  hcal1TiltAngle(0.27)
+  , hcal2TiltAngle(0.14)
+  , hcal1DPhi(0.27)
+  ,  // calculated based on Don's drawing.  (twopi/16.0);
+  hcal2DPhi(0.288)
+  ,  // calculated based on Don's drawing.  (twopi/16.0);
+  hcal1RadiusIn(1855 * mm)
+  , hcal2RadiusIn(hcal1RadiusIn + hcal1ScintSizeX)
+  ,
   // The frame box for the HCAL.
-  hcalBoxSizeX(1.1*(hcal2ScintSizeX + hcal1ScintSizeX)), 
-  hcalBoxSizeY(2.54*40.0*cm),    // need to get more accurate dimension for the box             
-  hcalBoxSizeZ(1.1*hcal2ScintSizeZ),
-  hcalBoxRotationAngle_z(0.0*rad),   // Rotation along z-axis
-  hcalBoxRotationAngle_y(0.0*rad),   // Rotation along y-axis
-  hcal2Abs_dxa(2.54*27.1*cm),   // these numbers are from Don't drawings
-  hcal2Abs_dxb(hcal2Abs_dxa),
-  hcal2Abs_dya(2.54*1.099*cm),
-  hcal2Abs_dyb(2.54*1.776*cm),
-  hcal2Abs_dz(hcal2ScintSizeZ),
-  hcal1Abs_dxa(hcal1ScintSizeX),  // these numbers are from Don't drawings
-  hcal1Abs_dxb(hcal1ScintSizeX),
-  hcal1Abs_dya(2.54*0.787*cm),
-  hcal1Abs_dyb(2.54*1.115*cm),    
-  hcal1Abs_dz(hcal1ScintSizeZ),
-  hcalJunctionSizeX(2.54*1.0*cm),
-  hcalJunctionSizeY(hcal2ScintSizeY),
-  hcalJunctionSizeZ(hcal2Abs_dz),
-  physiWorld(nullptr),
-  logicWorld(nullptr),
-  logicHcalBox(nullptr),
-  solidHcalBox(nullptr),
-  physiHcalBox(nullptr),
-  logicHcal2ScintLayer(nullptr),
-  logicHcal1ScintLayer(nullptr),
-  logicHcal2AbsLayer(nullptr),
-  logicHcal1AbsLayer(nullptr),
-  world_mat(nullptr),
-  steel(nullptr),
-  scint_mat(nullptr),
-  active(0),
-  absorberactive(0),
-  layer(lyr),
-  blackhole(0)
+  hcalBoxSizeX(1.1 * (hcal2ScintSizeX + hcal1ScintSizeX))
+  , hcalBoxSizeY(2.54 * 40.0 * cm)
+  ,  // need to get more accurate dimension for the box
+  hcalBoxSizeZ(1.1 * hcal2ScintSizeZ)
+  , hcalBoxRotationAngle_z(0.0 * rad)
+  ,  // Rotation along z-axis
+  hcalBoxRotationAngle_y(0.0 * rad)
+  ,  // Rotation along y-axis
+  hcal2Abs_dxa(2.54 * 27.1 * cm)
+  ,  // these numbers are from Don't drawings
+  hcal2Abs_dxb(hcal2Abs_dxa)
+  , hcal2Abs_dya(2.54 * 1.099 * cm)
+  , hcal2Abs_dyb(2.54 * 1.776 * cm)
+  , hcal2Abs_dz(hcal2ScintSizeZ)
+  , hcal1Abs_dxa(hcal1ScintSizeX)
+  ,  // these numbers are from Don't drawings
+  hcal1Abs_dxb(hcal1ScintSizeX)
+  , hcal1Abs_dya(2.54 * 0.787 * cm)
+  , hcal1Abs_dyb(2.54 * 1.115 * cm)
+  , hcal1Abs_dz(hcal1ScintSizeZ)
+  , hcalJunctionSizeX(2.54 * 1.0 * cm)
+  , hcalJunctionSizeY(hcal2ScintSizeY)
+  , hcalJunctionSizeZ(hcal2Abs_dz)
+  , physiWorld(nullptr)
+  , logicWorld(nullptr)
+  , logicHcalBox(nullptr)
+  , solidHcalBox(nullptr)
+  , physiHcalBox(nullptr)
+  , logicHcal2ScintLayer(nullptr)
+  , logicHcal1ScintLayer(nullptr)
+  , logicHcal2AbsLayer(nullptr)
+  , logicHcal1AbsLayer(nullptr)
+  , world_mat(nullptr)
+  , steel(nullptr)
+  , scint_mat(nullptr)
+  , active(0)
+  , absorberactive(0)
+  , layer(lyr)
+  , blackhole(0)
 {
-
-
-  // create commands for interactive definition of the detector  
+  // create commands for interactive definition of the detector
   fDetectorMessenger = new PHG4HcalPrototypeDetectorMessenger(this);
 }
 
 //_______________________________________________________________
 //_______________________________________________________________
-int
-PHG4HcalPrototypeDetector::IsInHcalPrototype(G4VPhysicalVolume * volume) const
+int PHG4HcalPrototypeDetector::IsInHcalPrototype(G4VPhysicalVolume* volume) const
 {
-
   return 0;  // not sure what value to return for now.
 }
 
-void PHG4HcalPrototypeDetector::ConstructMe( G4LogicalVolume* world )
+void PHG4HcalPrototypeDetector::ConstructMe(G4LogicalVolume* world)
 {
   logicWorld = world;
 
-
   DefineMaterials();
-  
-  ConstructDetector();
 
+  ConstructDetector();
 }
 
-
 void PHG4HcalPrototypeDetector::DefineMaterials()
-{ 
-
+{
   // Water is defined from NIST material database
-  G4NistManager * nist = G4NistManager::Instance();
-  
+  G4NistManager* nist = G4NistManager::Instance();
+
   world_mat = nist->FindOrBuildMaterial("G4_AIR");
 
-  steel = nist->FindOrBuildMaterial("G4_Fe"); // Need to fix this *******
+  steel = nist->FindOrBuildMaterial("G4_Fe");  // Need to fix this *******
   scint_mat = nist->FindOrBuildMaterial("G4_POLYSTYRENE");
-  
+
   G4cout << *(G4Material::GetMaterialTable()) << G4endl;
 }
 
 // We now build our detector solids, etc
-// 
-G4VPhysicalVolume*  PHG4HcalPrototypeDetector::ConstructDetector()
+//
+G4VPhysicalVolume* PHG4HcalPrototypeDetector::ConstructDetector()
 {
-
   // Option to switch on/off checking of volumes overlaps
   //
   G4bool checkOverlaps = true;
 
   // HCAL Frame Box for enclosing the inner and the outer hcal
   // which allows us to rotate the whole calorimeter easily
-  solidHcalBox = new G4Box("HcalBox",				           //its name
-			 hcalBoxSizeX/2,hcalBoxSizeY/2,hcalBoxSizeZ/2);    //its size
+  solidHcalBox = new G4Box("HcalBox",                                              //its name
+                           hcalBoxSizeX / 2, hcalBoxSizeY / 2, hcalBoxSizeZ / 2);  //its size
 
-  logicHcalBox = new G4LogicalVolume(solidHcalBox,      //its solid
-				     world_mat,	        //its material
-				     "HcalBox");        //its name
+  logicHcalBox = new G4LogicalVolume(solidHcalBox,  //its solid
+                                     world_mat,     //its material
+                                     "HcalBox");    //its name
 
   // Place the HcalBox inside the World
-  G4ThreeVector boxVector = G4ThreeVector(hcal1RadiusIn + hcalBoxSizeX/2.0,  0, 0); 
-  G4RotationMatrix rotBox  = G4RotationMatrix();
+  G4ThreeVector boxVector = G4ThreeVector(hcal1RadiusIn + hcalBoxSizeX / 2.0, 0, 0);
+  G4RotationMatrix rotBox = G4RotationMatrix();
 
-  rotBox.rotateZ(hcalBoxRotationAngle_z);     // Rotate the whole calorimeter box along z-axis
-  rotBox.rotateY(hcalBoxRotationAngle_y);     // Rotate the whole calorimeter box along z-axis
+  rotBox.rotateZ(hcalBoxRotationAngle_z);  // Rotate the whole calorimeter box along z-axis
+  rotBox.rotateY(hcalBoxRotationAngle_y);  // Rotate the whole calorimeter box along z-axis
 
   G4Transform3D boxTransform = G4Transform3D(rotBox, boxVector);
-  
-  physiHcalBox = new G4PVPlacement(boxTransform,        // rotation + positioning
-				   logicHcalBox,	//its logical volume
-				   "HcalBox",		//its name
-				   logicWorld,		//its mother  volume
-				   false,		//no boolean operation
-				   0,			//copy number
-				   checkOverlaps);      //checking overlaps
-  
+
+  physiHcalBox = new G4PVPlacement(boxTransform,    // rotation + positioning
+                                   logicHcalBox,    //its logical volume
+                                   "HcalBox",       //its name
+                                   logicWorld,      //its mother  volume
+                                   false,           //no boolean operation
+                                   0,               //copy number
+                                   checkOverlaps);  //checking overlaps
+
   // HCal Box visualization attributes
-  G4VisAttributes* hcalBoxVisAtt= new G4VisAttributes(G4Colour(0.0,0.0,1.0)); // blue
+  G4VisAttributes* hcalBoxVisAtt = new G4VisAttributes(G4Colour(0.0, 0.0, 1.0));  // blue
   hcalBoxVisAtt->SetVisibility(true);
   //hcalBoxVisAtt->SetForceSolid(true);
   logicHcalBox->SetVisAttributes(hcalBoxVisAtt);
 
-
   // Make outer hcal section
-  // 
+  //
   // Build scintillator layer box as a place holder for the scintillator sheets
   // Make it 0.05cm thinner than the true gap width for avoiding geometry overlaps
-  G4Box* hcal2ScintLayer = new G4Box("hcal2ScintLayer",		                              //its name
-				     hcal2ScintSizeX/2,(hcal2ScintSizeY-0.05*cm)/2,hcal2ScintSizeZ/2);  //its size
-  
-  
-  logicHcal2ScintLayer = 
-    new G4LogicalVolume(hcal2ScintLayer,      // its solid name
-			world_mat,            // material, the same as the material of the world valume
-			"hcal2ScintLayer");   // its name
-  
+  G4Box* hcal2ScintLayer = new G4Box("hcal2ScintLayer",                                                             //its name
+                                     hcal2ScintSizeX / 2, (hcal2ScintSizeY - 0.05 * cm) / 2, hcal2ScintSizeZ / 2);  //its size
+
+  logicHcal2ScintLayer =
+      new G4LogicalVolume(hcal2ScintLayer,     // its solid name
+                          world_mat,           // material, the same as the material of the world valume
+                          "hcal2ScintLayer");  // its name
+
   // Scintillator visualization attributes
-  G4VisAttributes* scintVisAtt= new G4VisAttributes(G4Colour(1.0,0.0,0.0)); //Red
+  G4VisAttributes* scintVisAtt = new G4VisAttributes(G4Colour(1.0, 0.0, 0.0));  //Red
   scintVisAtt->SetVisibility(true);
   //scintVisAtt->SetForceSolid(true);
   logicHcal2ScintLayer->SetVisAttributes(scintVisAtt);
 
   // Construct outer scintillator 1U
-  G4double outer1UpDz = 649.8*mm;
-  G4double outer1UpDy1 = 2*0.35*cm;
-  G4double outer1UpDx2 = 179.3*mm;
-  G4double outer1UpDx4 = 113.2*mm;
+  G4double outer1UpDz = 649.8 * mm;
+  G4double outer1UpDy1 = 2 * 0.35 * cm;
+  G4double outer1UpDx2 = 179.3 * mm;
+  G4double outer1UpDx4 = 113.2 * mm;
 
-  G4Trap *outer1USheetSolid = new G4Trap("outer1USheet",                      //its name
-					 outer1UpDy1, outer1UpDz, 
-					 outer1UpDx2, outer1UpDx4); //its size
-    
-  G4LogicalVolume *logicOuter1USheet = new G4LogicalVolume(outer1USheetSolid, 
-							 scint_mat,
-							 "outer1USheet");
+  G4Trap* outer1USheetSolid = new G4Trap("outer1USheet",  //its name
+                                         outer1UpDy1, outer1UpDz,
+                                         outer1UpDx2, outer1UpDx4);  //its size
+
+  G4LogicalVolume* logicOuter1USheet = new G4LogicalVolume(outer1USheetSolid,
+                                                           scint_mat,
+                                                           "outer1USheet");
 
   // Scintillator visualization attributes
-  G4VisAttributes* scintSheetVisAtt= new G4VisAttributes(G4Colour(0.5,0.5,0.0)); //White
+  G4VisAttributes* scintSheetVisAtt = new G4VisAttributes(G4Colour(0.5, 0.5, 0.0));  //White
   scintSheetVisAtt->SetVisibility(true);
   scintSheetVisAtt->SetForceSolid(true);
 
@@ -214,183 +218,180 @@ G4VPhysicalVolume*  PHG4HcalPrototypeDetector::ConstructDetector()
 
   // Detector placement
   // Position the outer right 1U sheet
-  G4ThreeVector threeVecOuter1U_1 = G4ThreeVector(0*cm, 0*cm, -0.252*(outer1UpDx2+outer1UpDx4));
-  G4RotationMatrix rot1U_1  = G4RotationMatrix();
-  rot1U_1.rotateZ(90*deg);
-  rot1U_1.rotateX(-90*deg);
+  G4ThreeVector threeVecOuter1U_1 = G4ThreeVector(0 * cm, 0 * cm, -0.252 * (outer1UpDx2 + outer1UpDx4));
+  G4RotationMatrix rot1U_1 = G4RotationMatrix();
+  rot1U_1.rotateZ(90 * deg);
+  rot1U_1.rotateX(-90 * deg);
 
-  G4Transform3D transformOuter1U_1 = G4Transform3D(rot1U_1,threeVecOuter1U_1);
+  G4Transform3D transformOuter1U_1 = G4Transform3D(rot1U_1, threeVecOuter1U_1);
 
   new G4PVPlacement(transformOuter1U_1,
-		    logicOuter1USheet,
-		    "outer1USheet",
-		    logicHcal2ScintLayer,
-		    false,
-		    0,                    // Copy one
-		    checkOverlaps);
+                    logicOuter1USheet,
+                    "outer1USheet",
+                    logicHcal2ScintLayer,
+                    false,
+                    0,  // Copy one
+                    checkOverlaps);
 
-  
   // Detector placement
   // Position the outer left 1U sheet
-  G4ThreeVector threeVecOuter1U_2 = G4ThreeVector(0*cm, 0*cm, 0.252*(outer1UpDx2+outer1UpDx4));
-  G4RotationMatrix rot1U_2  = G4RotationMatrix();
-  rot1U_2.rotateZ(90*deg);
-  rot1U_2.rotateX(90*deg);
+  G4ThreeVector threeVecOuter1U_2 = G4ThreeVector(0 * cm, 0 * cm, 0.252 * (outer1UpDx2 + outer1UpDx4));
+  G4RotationMatrix rot1U_2 = G4RotationMatrix();
+  rot1U_2.rotateZ(90 * deg);
+  rot1U_2.rotateX(90 * deg);
 
-  G4Transform3D transformOuter1U_2 = G4Transform3D(rot1U_2,threeVecOuter1U_2);
+  G4Transform3D transformOuter1U_2 = G4Transform3D(rot1U_2, threeVecOuter1U_2);
 
   new G4PVPlacement(transformOuter1U_2,
-		    logicOuter1USheet,
-		    "outer1USheet",
-		    logicHcal2ScintLayer,
-		    false,
-		    1,                      // Copy two
-		    checkOverlaps);
+                    logicOuter1USheet,
+                    "outer1USheet",
+                    logicHcal2ScintLayer,
+                    false,
+                    1,  // Copy two
+                    checkOverlaps);
 
-  // Construct outer scintillator 2U 
-  G4double outer2UpDz = 0.5*649.8*mm;
-  G4double outer2UpTheta = 8.8*M_PI/180.;
-  G4double outer2UpPhi = 0.0*M_PI/180.;
-  G4double outer2UpDy1 = 0.35*cm;
-  G4double outer2UpDy2 = 0.35*cm;
-  G4double outer2UpDx1 = 0.5*179.3*mm, outer2UpDx2 = 0.5*179.3*mm;
-  G4double outer2UpDx3 = 0.5*113.2*mm, outer2UpDx4 = 0.5*113.2*mm;
-  G4double outer2UpAlp1 = 0.*M_PI/180., outer2UpAlp2 = 0.*M_PI/180;
+  // Construct outer scintillator 2U
+  G4double outer2UpDz = 0.5 * 649.8 * mm;
+  G4double outer2UpTheta = 8.8 * M_PI / 180.;
+  G4double outer2UpPhi = 0.0 * M_PI / 180.;
+  G4double outer2UpDy1 = 0.35 * cm;
+  G4double outer2UpDy2 = 0.35 * cm;
+  G4double outer2UpDx1 = 0.5 * 179.3 * mm, outer2UpDx2 = 0.5 * 179.3 * mm;
+  G4double outer2UpDx3 = 0.5 * 113.2 * mm, outer2UpDx4 = 0.5 * 113.2 * mm;
+  G4double outer2UpAlp1 = 0. * M_PI / 180., outer2UpAlp2 = 0. * M_PI / 180;
 
-  G4Trap *outer2USheetSolid = new G4Trap("outer2USheet",
-				  outer2UpDz,
-				  outer2UpTheta,
-				  outer2UpPhi, 
-				  outer2UpDy1,
-				  outer2UpDx1,
-				  outer2UpDx2,
-				  outer2UpAlp1,
-				  outer2UpDy2,
-				  outer2UpDx3,
-				  outer2UpDx4,
-				  outer2UpAlp2);
+  G4Trap* outer2USheetSolid = new G4Trap("outer2USheet",
+                                         outer2UpDz,
+                                         outer2UpTheta,
+                                         outer2UpPhi,
+                                         outer2UpDy1,
+                                         outer2UpDx1,
+                                         outer2UpDx2,
+                                         outer2UpAlp1,
+                                         outer2UpDy2,
+                                         outer2UpDx3,
+                                         outer2UpDx4,
+                                         outer2UpAlp2);
 
-  G4LogicalVolume *logicOuter2USheet = new G4LogicalVolume(outer2USheetSolid, 
-							 scint_mat,
-							 "outer2USheet");
+  G4LogicalVolume* logicOuter2USheet = new G4LogicalVolume(outer2USheetSolid,
+                                                           scint_mat,
+                                                           "outer2USheet");
 
   logicOuter2USheet->SetVisAttributes(scintSheetVisAtt);
 
-  
   // Detector placement
   // Position the right most sheet
-  G4ThreeVector threeVecOuter2U_1 = G4ThreeVector(0*cm, 0*cm, -0.755*(outer1UpDx2+outer1UpDx4));
-  G4RotationMatrix rot2U_1  = G4RotationMatrix();
-  rot2U_1.rotateY(-90*deg);
+  G4ThreeVector threeVecOuter2U_1 = G4ThreeVector(0 * cm, 0 * cm, -0.755 * (outer1UpDx2 + outer1UpDx4));
+  G4RotationMatrix rot2U_1 = G4RotationMatrix();
+  rot2U_1.rotateY(-90 * deg);
 
-  G4Transform3D transformOuter2U_1 = G4Transform3D(rot2U_1,threeVecOuter2U_1);
+  G4Transform3D transformOuter2U_1 = G4Transform3D(rot2U_1, threeVecOuter2U_1);
 
   new G4PVPlacement(transformOuter2U_1,
-		    logicOuter2USheet,
-		    "outer2USheet",
-		    logicHcal2ScintLayer,
-		    false,
-		    0,                     // copy one
-		    checkOverlaps);
+                    logicOuter2USheet,
+                    "outer2USheet",
+                    logicHcal2ScintLayer,
+                    false,
+                    0,  // copy one
+                    checkOverlaps);
 
-  
   // Detector placement
   // Position the outer left most sheet
-  G4ThreeVector threeVecOuter2U_2 = G4ThreeVector(0*cm, 0*cm, 0.755*(outer1UpDx2+outer1UpDx4));
-  G4RotationMatrix rot2U_2  = G4RotationMatrix();
-  rot2U_2.rotateY(-90*deg);
-  rot2U_2.rotateX(180*deg);
+  G4ThreeVector threeVecOuter2U_2 = G4ThreeVector(0 * cm, 0 * cm, 0.755 * (outer1UpDx2 + outer1UpDx4));
+  G4RotationMatrix rot2U_2 = G4RotationMatrix();
+  rot2U_2.rotateY(-90 * deg);
+  rot2U_2.rotateX(180 * deg);
 
-  G4Transform3D transformOuter2U_2 = G4Transform3D(rot2U_2,threeVecOuter2U_2);
+  G4Transform3D transformOuter2U_2 = G4Transform3D(rot2U_2, threeVecOuter2U_2);
 
   new G4PVPlacement(transformOuter2U_2,
-		    logicOuter2USheet,
-		    "outer2USheet",
-		    logicHcal2ScintLayer,
-		    false,
-		    1,                     // copy two
-		    checkOverlaps);  
-  
-  G4Trap* hcal2AbsLayer =    
-    new G4Trap("hcal2AbsLayer",                      //its name
-	       hcal2Abs_dz, hcal2Abs_dxa, 
-	       hcal2Abs_dyb, hcal2Abs_dya); //its size
-  
+                    logicOuter2USheet,
+                    "outer2USheet",
+                    logicHcal2ScintLayer,
+                    false,
+                    1,  // copy two
+                    checkOverlaps);
+
+  G4Trap* hcal2AbsLayer =
+      new G4Trap("hcal2AbsLayer",  //its name
+                 hcal2Abs_dz, hcal2Abs_dxa,
+                 hcal2Abs_dyb, hcal2Abs_dya);  //its size
+
   // Add extra absorber materials at the junction
-  G4Box* hcalJunction = new G4Box("HcalJunction",		     //its name
-				  hcalJunctionSizeX/2, hcalJunctionSizeY/2, hcalJunctionSizeZ/2);  //its size
-  
+  G4Box* hcalJunction = new G4Box("HcalJunction",                                                        //its name
+                                  hcalJunctionSizeX / 2, hcalJunctionSizeY / 2, hcalJunctionSizeZ / 2);  //its size
+
   // define the transformation for placing the junction to the inner side of the hcal2 absorber layer
-  G4ThreeVector threeVecJunction = G4ThreeVector( -hcal2Abs_dya/2.0 - 1.1*hcalJunctionSizeY , hcal2Abs_dxa/2.0 - hcalJunctionSizeX/2, 0.0*cm);
-  G4RotationMatrix rotJunction  = G4RotationMatrix();
-  rotJunction.rotateZ(90*deg);
-  rotJunction.rotateX(0*deg);
-  G4Transform3D transformJunction = G4Transform3D(rotJunction,threeVecJunction);
-  
+  G4ThreeVector threeVecJunction = G4ThreeVector(-hcal2Abs_dya / 2.0 - 1.1 * hcalJunctionSizeY, hcal2Abs_dxa / 2.0 - hcalJunctionSizeX / 2, 0.0 * cm);
+  G4RotationMatrix rotJunction = G4RotationMatrix();
+  rotJunction.rotateZ(90 * deg);
+  rotJunction.rotateX(0 * deg);
+  G4Transform3D transformJunction = G4Transform3D(rotJunction, threeVecJunction);
+
   // attach the junction to the absorber using G4UnionSolid
   G4UnionSolid* hcal2AbsLayerJunct = new G4UnionSolid("hcal2AbsLayerJunct", hcal2AbsLayer, hcalJunction, transformJunction);
-  
-  logicHcal2AbsLayer = new G4LogicalVolume(hcal2AbsLayerJunct,    //  hcal2AbsLayer,
-					   steel,
-					   "hcal2AbsLayer");
+
+  logicHcal2AbsLayer = new G4LogicalVolume(hcal2AbsLayerJunct,  //  hcal2AbsLayer,
+                                           steel,
+                                           "hcal2AbsLayer");
 
   // hcal2Aborber visualization attributes
-  G4VisAttributes* hcal2AbsVisAtt= new G4VisAttributes(G4Colour(0.5,0.5,1.0)); 
+  G4VisAttributes* hcal2AbsVisAtt = new G4VisAttributes(G4Colour(0.5, 0.5, 1.0));
   hcal2AbsVisAtt->SetVisibility(true);
   logicHcal2AbsLayer->SetVisAttributes(hcal2AbsVisAtt);
-      
-  // place scintillator layers insides the HCal2 absorber volume 
+
+  // place scintillator layers insides the HCal2 absorber volume
   //
-  
 
   G4double theta = 0.;
-  G4double theta2 = hcal2TiltAngle;   // I am not convinced that I got the tilt angle right.  So I simply forced it to 
-  G4double rScintLayerCenter = hcal2RadiusIn + hcal2ScintSizeX/2.0 + 2.54*1.0*cm;  // move the scintillator toward the rear end of HCAL2
-  G4double RmidScintLayerX =  0.81*(hcal2ScintSizeX - hcal1ScintSizeX)/2.0 + 2.54*1.0*cm + 2*2.54*cm;  // move the scintillator toward the rear end of HCAL2
-  G4double rAbsLayerCenter = hcal2RadiusIn + hcal2Abs_dxa/2.0;
-  G4double RmidAbsLayerX =  0.81*(hcal2Abs_dxa - hcal1ScintSizeX)/2.0 + 2*2.54*cm;
+  G4double theta2 = hcal2TiltAngle;                                                                               // I am not convinced that I got the tilt angle right.  So I simply forced it to
+  G4double rScintLayerCenter = hcal2RadiusIn + hcal2ScintSizeX / 2.0 + 2.54 * 1.0 * cm;                           // move the scintillator toward the rear end of HCAL2
+  G4double RmidScintLayerX = 0.81 * (hcal2ScintSizeX - hcal1ScintSizeX) / 2.0 + 2.54 * 1.0 * cm + 2 * 2.54 * cm;  // move the scintillator toward the rear end of HCAL2
+  G4double rAbsLayerCenter = hcal2RadiusIn + hcal2Abs_dxa / 2.0;
+  G4double RmidAbsLayerX = 0.81 * (hcal2Abs_dxa - hcal1ScintSizeX) / 2.0 + 2 * 2.54 * cm;
   G4int LayerNum = 1;
   G4double xPadding = 0.0;
   G4double yPadding = 0.0;
   G4double tiltPadding = 0.0;
 
-  for (G4int iLayer = -nHcal2Layers/2; iLayer < nHcal2Layers/2; iLayer++ ) { 
+  for (G4int iLayer = -nHcal2Layers / 2; iLayer < nHcal2Layers / 2; iLayer++)
+  {
     //
     // Place outer absorber layer first
     //
-    theta = hcal2DPhi/nHcal2Layers * iLayer;
+    theta = hcal2DPhi / nHcal2Layers * iLayer;
     G4double xposShift = rAbsLayerCenter * (cos(theta) - 1.0);
     G4double yposShift = rAbsLayerCenter * sin(theta);
-    xPadding = 0.013*RmidAbsLayerX*LayerNum;      // adding an extra padding for placing the absorber and scintillator 
-    G4ThreeVector absTrans = G4ThreeVector(RmidAbsLayerX + xposShift - xPadding, yposShift, 0); 
-    G4RotationMatrix rotAbsLayer  = G4RotationMatrix();
-    rotAbsLayer.rotateY(90*deg);
-    rotAbsLayer.rotateX(90*deg);
-    rotAbsLayer.rotateY(-90*deg);
-    tiltPadding = LayerNum*0.005*rad;
-    rotAbsLayer.rotateZ((iLayer + nHcal2Layers/2)*0.02*rad + tiltPadding);   // Added a funge increment factor 0.01
-    
-    G4Transform3D transformAbs = G4Transform3D(rotAbsLayer,absTrans);
-    
-    new G4PVPlacement(transformAbs,            //rotation,position
-		      logicHcal2AbsLayer,      //its logical volume
-		      "hcal2AbsLayer",         //its name
-		      logicHcalBox,            //its mother  volume
-		      false,                   //no boolean operation
-		      LayerNum - 1,            //copy number
-		      checkOverlaps);          //overlaps checking 
+    xPadding = 0.013 * RmidAbsLayerX * LayerNum;  // adding an extra padding for placing the absorber and scintillator
+    G4ThreeVector absTrans = G4ThreeVector(RmidAbsLayerX + xposShift - xPadding, yposShift, 0);
+    G4RotationMatrix rotAbsLayer = G4RotationMatrix();
+    rotAbsLayer.rotateY(90 * deg);
+    rotAbsLayer.rotateX(90 * deg);
+    rotAbsLayer.rotateY(-90 * deg);
+    tiltPadding = LayerNum * 0.005 * rad;
+    rotAbsLayer.rotateZ((iLayer + nHcal2Layers / 2) * 0.02 * rad + tiltPadding);  // Added a funge increment factor 0.01
+
+    G4Transform3D transformAbs = G4Transform3D(rotAbsLayer, absTrans);
+
+    new G4PVPlacement(transformAbs,        //rotation,position
+                      logicHcal2AbsLayer,  //its logical volume
+                      "hcal2AbsLayer",     //its name
+                      logicHcalBox,        //its mother  volume
+                      false,               //no boolean operation
+                      LayerNum - 1,        //copy number
+                      checkOverlaps);      //overlaps checking
     //
     // Place outer hcal scintillator layer
     //
-    theta += 0.5*hcal2DPhi/nHcal2Layers; 
+    theta += 0.5 * hcal2DPhi / nHcal2Layers;
     G4cout << "M_PI: " << M_PI << "     theta: " << theta << "    TileAngle: " << theta2 << G4endl;
     xposShift = rScintLayerCenter * (cos(theta) - 1.0);
     yposShift = rScintLayerCenter * sin(theta);
-    G4ThreeVector myTrans = G4ThreeVector(RmidScintLayerX + xposShift - xPadding, yposShift+0.3*cm, 0); // hcal2RadiusIn + hcal1ScintSizeX/2.0
-    G4RotationMatrix rotm  = G4RotationMatrix();
-    rotm.rotateZ((iLayer + nHcal2Layers/2 + 1)*0.020*rad+tiltPadding);        // Added a funge increment factor 0.02
-    G4Transform3D transform = G4Transform3D(rotm,myTrans);
-     
+    G4ThreeVector myTrans = G4ThreeVector(RmidScintLayerX + xposShift - xPadding, yposShift + 0.3 * cm, 0);  // hcal2RadiusIn + hcal1ScintSizeX/2.0
+    G4RotationMatrix rotm = G4RotationMatrix();
+    rotm.rotateZ((iLayer + nHcal2Layers / 2 + 1) * 0.020 * rad + tiltPadding);  // Added a funge increment factor 0.02
+    G4Transform3D transform = G4Transform3D(rotm, myTrans);
+
     G4cout << "  iLayer " << iLayer << G4endl;
 
     new G4PVPlacement(transform,             //rotation,position
@@ -399,236 +400,229 @@ G4VPhysicalVolume*  PHG4HcalPrototypeDetector::ConstructDetector()
                       logicHcalBox,          //its mother volume
                       false,                 //no boolean operation
                       LayerNum - 1,          //copy number
-                      checkOverlaps);        //checking overlaps 
+                      checkOverlaps);        //checking overlaps
     LayerNum++;
-
   }
 
   // Make INNER hcal section
-  // 
+  //
   // Build scintillator layer box as a place holder for the scintillator sheets
   // Make it 0.05cm thinner than the true gap width for avoiding geometry overlaps
-  G4Box* hcal1ScintLayer = new G4Box("hcal1ScintLayer",		                              //its name
-				     hcal1ScintSizeX/2,(hcal1ScintSizeY-0.05*cm)/2,hcal1ScintSizeZ/2);  //its size
+  G4Box* hcal1ScintLayer = new G4Box("hcal1ScintLayer",                                                             //its name
+                                     hcal1ScintSizeX / 2, (hcal1ScintSizeY - 0.05 * cm) / 2, hcal1ScintSizeZ / 2);  //its size
 
-  logicHcal1ScintLayer = 
-    new G4LogicalVolume(hcal1ScintLayer,     // its solid name
-			world_mat,           // simply use world material
-			"hcal1ScintLayer");  // its name
+  logicHcal1ScintLayer =
+      new G4LogicalVolume(hcal1ScintLayer,     // its solid name
+                          world_mat,           // simply use world material
+                          "hcal1ScintLayer");  // its name
 
   logicHcal1ScintLayer->SetVisAttributes(scintVisAtt);
 
   // Constructing scintillator sheets
   // Construct inner scintillator 1U
   // The numbers are read off from Don's drawings
-  G4double inner1UpDz = 316.8*mm;
-  G4double inner1UpDy1 = 2*0.35*cm;
-  G4double inner1UpDx2 = 108.6*mm;
-  G4double inner1UpDx4 = 77.4*mm;
+  G4double inner1UpDz = 316.8 * mm;
+  G4double inner1UpDy1 = 2 * 0.35 * cm;
+  G4double inner1UpDx2 = 108.6 * mm;
+  G4double inner1UpDx4 = 77.4 * mm;
 
-  G4Trap *inner1USheetSolid = new G4Trap("inner1USheet",             //its name
-					 inner1UpDy1, inner1UpDz, 
-					 inner1UpDx2, inner1UpDx4);  //its size
-    
-  G4LogicalVolume *logicInner1USheet = new G4LogicalVolume(inner1USheetSolid, 
-							 scint_mat,
-							 "inner1USheet");
+  G4Trap* inner1USheetSolid = new G4Trap("inner1USheet",  //its name
+                                         inner1UpDy1, inner1UpDz,
+                                         inner1UpDx2, inner1UpDx4);  //its size
+
+  G4LogicalVolume* logicInner1USheet = new G4LogicalVolume(inner1USheetSolid,
+                                                           scint_mat,
+                                                           "inner1USheet");
   logicInner1USheet->SetVisAttributes(scintSheetVisAtt);
 
   // Detector placement
   // Position the inner right 1U sheet
-  G4ThreeVector threeVecInner1U_1_inner = G4ThreeVector(0*cm, 0*cm, -0.252*(inner1UpDx2+inner1UpDx4));
+  G4ThreeVector threeVecInner1U_1_inner = G4ThreeVector(0 * cm, 0 * cm, -0.252 * (inner1UpDx2 + inner1UpDx4));
 
-  G4Transform3D transformInner1U_1 = G4Transform3D(rot1U_1,threeVecInner1U_1_inner);
+  G4Transform3D transformInner1U_1 = G4Transform3D(rot1U_1, threeVecInner1U_1_inner);
 
   new G4PVPlacement(transformInner1U_1,
-		    logicInner1USheet,
-		    "inner1USheet",
-		    logicHcal1ScintLayer,
-		    false,
-		    0,                    // Copy one
-		    checkOverlaps);
+                    logicInner1USheet,
+                    "inner1USheet",
+                    logicHcal1ScintLayer,
+                    false,
+                    0,  // Copy one
+                    checkOverlaps);
 
-  
   // Detector placement
   // Position the inner left 1U sheet
-  G4ThreeVector threeVecInner1U_2_inner = G4ThreeVector(0*cm, 0*cm, 0.252*(inner1UpDx2+inner1UpDx4));
+  G4ThreeVector threeVecInner1U_2_inner = G4ThreeVector(0 * cm, 0 * cm, 0.252 * (inner1UpDx2 + inner1UpDx4));
   //G4RotationMatrix rot1U_2  = G4RotationMatrix();
   //rot1U_2.rotateZ(90*deg);
   //rot1U_2.rotateX(90*deg);
 
-  G4Transform3D transformInner1U_2 = G4Transform3D(rot1U_2,threeVecInner1U_2_inner);
+  G4Transform3D transformInner1U_2 = G4Transform3D(rot1U_2, threeVecInner1U_2_inner);
 
   new G4PVPlacement(transformInner1U_2,
-		    logicInner1USheet,
-		    "inner1USheet",
-		    //logicWorld,
-		    logicHcal1ScintLayer,
-		    false,
-		    1,                      // Copy two
-		    checkOverlaps);
+                    logicInner1USheet,
+                    "inner1USheet",
+                    //logicWorld,
+                    logicHcal1ScintLayer,
+                    false,
+                    1,  // Copy two
+                    checkOverlaps);
 
-  // Construct inner scintillator 2U 
-  G4double inner2UpDz = 0.5*316.8*mm;
-  G4double inner2UpTheta = 8.8*M_PI/180.;
-  G4double inner2UpPhi = 0.0*M_PI/180.;
-  G4double inner2UpDy1 = 0.35*cm;
-  G4double inner2UpDy2 = 0.35*cm;
-  G4double inner2UpDx1 = 0.5*108.6*mm, inner2UpDx2 = 0.5*108.6*mm;
-  G4double inner2UpDx3 = 0.5*77.4*mm, inner2UpDx4 = 0.5*77.4*mm;
-  G4double inner2UpAlp1 = 0.*M_PI/180., inner2UpAlp2 = 0.*M_PI/180;
+  // Construct inner scintillator 2U
+  G4double inner2UpDz = 0.5 * 316.8 * mm;
+  G4double inner2UpTheta = 8.8 * M_PI / 180.;
+  G4double inner2UpPhi = 0.0 * M_PI / 180.;
+  G4double inner2UpDy1 = 0.35 * cm;
+  G4double inner2UpDy2 = 0.35 * cm;
+  G4double inner2UpDx1 = 0.5 * 108.6 * mm, inner2UpDx2 = 0.5 * 108.6 * mm;
+  G4double inner2UpDx3 = 0.5 * 77.4 * mm, inner2UpDx4 = 0.5 * 77.4 * mm;
+  G4double inner2UpAlp1 = 0. * M_PI / 180., inner2UpAlp2 = 0. * M_PI / 180;
 
-  G4Trap *inner2USheetSolid = new G4Trap("inner2USheet",
-				  inner2UpDz,
-				  inner2UpTheta,
-				  inner2UpPhi, 
-				  inner2UpDy1,
-				  inner2UpDx1,
-				  inner2UpDx2,
-				  inner2UpAlp1,
-				  inner2UpDy2,
-				  inner2UpDx3,
-				  inner2UpDx4,
-				  inner2UpAlp2);
+  G4Trap* inner2USheetSolid = new G4Trap("inner2USheet",
+                                         inner2UpDz,
+                                         inner2UpTheta,
+                                         inner2UpPhi,
+                                         inner2UpDy1,
+                                         inner2UpDx1,
+                                         inner2UpDx2,
+                                         inner2UpAlp1,
+                                         inner2UpDy2,
+                                         inner2UpDx3,
+                                         inner2UpDx4,
+                                         inner2UpAlp2);
 
-  G4LogicalVolume *logicInner2USheet = new G4LogicalVolume(inner2USheetSolid, 
-							 scint_mat,
-							 "inner2USheet");
+  G4LogicalVolume* logicInner2USheet = new G4LogicalVolume(inner2USheetSolid,
+                                                           scint_mat,
+                                                           "inner2USheet");
 
   logicInner2USheet->SetVisAttributes(scintSheetVisAtt);
 
-  
   // Detector placement
   // Position the right most sheet
-  G4ThreeVector threeVecInner2U_1_inner = G4ThreeVector(0*cm, 0*cm, -0.755*(inner1UpDx2+inner1UpDx4));
+  G4ThreeVector threeVecInner2U_1_inner = G4ThreeVector(0 * cm, 0 * cm, -0.755 * (inner1UpDx2 + inner1UpDx4));
   //G4RotationMatrix rot2U_1  = G4RotationMatrix();
   //rot2U_1.rotateY(-90*deg);
 
-  G4Transform3D transformInner2U_1 = G4Transform3D(rot2U_1,threeVecInner2U_1_inner);
+  G4Transform3D transformInner2U_1 = G4Transform3D(rot2U_1, threeVecInner2U_1_inner);
 
   new G4PVPlacement(transformInner2U_1,
-		    logicInner2USheet,
-		    "inner2USheet",
-		    //logicWorld,
-		    logicHcal1ScintLayer,
-		    false,
-		    0,                     // copy one
-		    checkOverlaps);
+                    logicInner2USheet,
+                    "inner2USheet",
+                    //logicWorld,
+                    logicHcal1ScintLayer,
+                    false,
+                    0,  // copy one
+                    checkOverlaps);
 
-  
   // Detector placement
   // Position the inner left most sheet
-  G4ThreeVector threeVecInner2U_2_inner = G4ThreeVector(0*cm, 0*cm, 0.755*(inner1UpDx2+inner1UpDx4));
+  G4ThreeVector threeVecInner2U_2_inner = G4ThreeVector(0 * cm, 0 * cm, 0.755 * (inner1UpDx2 + inner1UpDx4));
   //G4RotationMatrix rot2U_2  = G4RotationMatrix();
   //rot2U_2.rotateY(-90*deg);
   //rot2U_2.rotateX(180*deg);
 
-  G4Transform3D transformInner2U_2 = G4Transform3D(rot2U_2,threeVecInner2U_2_inner);
+  G4Transform3D transformInner2U_2 = G4Transform3D(rot2U_2, threeVecInner2U_2_inner);
 
   new G4PVPlacement(transformInner2U_2,
-		    logicInner2USheet,
-		    "inner2USheet",
-		    //logicWorld,
-		    logicHcal1ScintLayer,
-		    false,
-		    1,                     // copy two
-		    checkOverlaps);  
-  
+                    logicInner2USheet,
+                    "inner2USheet",
+                    //logicWorld,
+                    logicHcal1ScintLayer,
+                    false,
+                    1,  // copy two
+                    checkOverlaps);
 
-  // Build hcal1 absorber layer in trapezoid shape 
-  //    
+  // Build hcal1 absorber layer in trapezoid shape
+  //
   /*
   G4double hcal1Abs_dxa = hcal1ScintSizeX; // hcal1Abs_dxb = hcal1ScintSizeX;
   G4double hcal1Abs_dya = 0.787*2.54*cm, hcal1Abs_dyb = 1.115*2.54*cm;    
   // these numbers are from Don't drawings
   G4double hcal1Abs_dz  = hcal1ScintSizeZ; 
   */
-  G4Trap* hcal1AbsLayer =    
-    new G4Trap("hcal1AbsLayer",                 //its name
-	       hcal1Abs_dz, hcal1Abs_dxa, 
-	       hcal1Abs_dyb, hcal1Abs_dya);      //its size
-  
+  G4Trap* hcal1AbsLayer =
+      new G4Trap("hcal1AbsLayer",  //its name
+                 hcal1Abs_dz, hcal1Abs_dxa,
+                 hcal1Abs_dyb, hcal1Abs_dya);  //its size
+
   logicHcal1AbsLayer = new G4LogicalVolume(hcal1AbsLayer,
-					   steel,
-							 "hcal1AbsLayer"); 
+                                           steel,
+                                           "hcal1AbsLayer");
 
   logicHcal1AbsLayer->SetVisAttributes(hcal2AbsVisAtt);
 
-  // place scintillator layers insides the HCal1 absorber volume 
+  // place scintillator layers insides the HCal1 absorber volume
   //
   // Calculate the title angle
 
   theta2 = hcal1TiltAngle;
   rAbsLayerCenter = hcal1RadiusIn + hcal1ScintSizeX / 2.0;
   //  RmidAbsLayerX =  (hcal2Abs_dxa - hcal1ScintSizeX)/2.0;
-  RmidAbsLayerX =  hcal2Abs_dxa/2.0;
-  LayerNum = 1;          // These three parameters are for making fine adjustment of the placement of inner hcal
-  yPadding = -2.54*0.8*cm;
-  for (G4int iLayer = -nHcal2Layers/2 -1; iLayer < nHcal2Layers/2 - 1; iLayer++) {  // shift one layer down
+  RmidAbsLayerX = hcal2Abs_dxa / 2.0;
+  LayerNum = 1;  // These three parameters are for making fine adjustment of the placement of inner hcal
+  yPadding = -2.54 * 0.8 * cm;
+  for (G4int iLayer = -nHcal2Layers / 2 - 1; iLayer < nHcal2Layers / 2 - 1; iLayer++)
+  {  // shift one layer down
     //
     // Place inner absorber layer first
     //
-    theta = hcal1DPhi/nHcal1Layers * iLayer;  // add an off set 0.01 rad
+    theta = hcal1DPhi / nHcal1Layers * iLayer;  // add an off set 0.01 rad
     G4double xposShift = rAbsLayerCenter * (cos(theta) - 1.0);
     G4double yposShift = rAbsLayerCenter * sin(theta);
-    xPadding = 0.005*RmidAbsLayerX*LayerNum - 2.54*1.9*cm;
-    G4ThreeVector absTrans = G4ThreeVector(-RmidAbsLayerX*cos(theta) + xposShift - xPadding, yposShift + yPadding, 0); 
-    G4RotationMatrix rotAbsLayer  = G4RotationMatrix();
-    rotAbsLayer.rotateY(90*deg);
-    rotAbsLayer.rotateX(90*deg);
-    rotAbsLayer.rotateY(-90*deg);
-    tiltPadding = LayerNum*0.005*rad;
-    rotAbsLayer.rotateZ((theta-theta2)*rad + tiltPadding);
+    xPadding = 0.005 * RmidAbsLayerX * LayerNum - 2.54 * 1.9 * cm;
+    G4ThreeVector absTrans = G4ThreeVector(-RmidAbsLayerX * cos(theta) + xposShift - xPadding, yposShift + yPadding, 0);
+    G4RotationMatrix rotAbsLayer = G4RotationMatrix();
+    rotAbsLayer.rotateY(90 * deg);
+    rotAbsLayer.rotateX(90 * deg);
+    rotAbsLayer.rotateY(-90 * deg);
+    tiltPadding = LayerNum * 0.005 * rad;
+    rotAbsLayer.rotateZ((theta - theta2) * rad + tiltPadding);
     //rotAbsLayer.rotateZ(-(iLayer + nHcal2Layers/2)*0.02*rad + tiltPadding);
-    
-    G4Transform3D transformAbs = G4Transform3D(rotAbsLayer,absTrans);
-    
-    new G4PVPlacement(transformAbs,              //rotation,position
-		      logicHcal1AbsLayer,        //its logical volume
-		      "hcal1AbsLayer",           //its name
-		      logicHcalBox,              //its mother  volume
-		      false,                     //no boolean operation
-		      LayerNum - 1,              //copy number
-		      checkOverlaps);            //overlaps checking
+
+    G4Transform3D transformAbs = G4Transform3D(rotAbsLayer, absTrans);
+
+    new G4PVPlacement(transformAbs,        //rotation,position
+                      logicHcal1AbsLayer,  //its logical volume
+                      "hcal1AbsLayer",     //its name
+                      logicHcalBox,        //its mother  volume
+                      false,               //no boolean operation
+                      LayerNum - 1,        //copy number
+                      checkOverlaps);      //overlaps checking
 
     //
     // Place inner hcal scintillator layer
     //
 
-    theta += 0.5*hcal1DPhi/nHcal1Layers;
+    theta += 0.5 * hcal1DPhi / nHcal1Layers;
     //G4cout << "M_PI: " << M_PI << "     theta: " << theta << "    TileAngle: " << theta2 << G4endl;
     //G4double phi = iLayer*dPhi;
-    //    G4ThreeVector myTrans = G4ThreeVector(-RmidAbsLayerX*cos(theta) + xposShift,  yposShift, 0); 
+    //    G4ThreeVector myTrans = G4ThreeVector(-RmidAbsLayerX*cos(theta) + xposShift,  yposShift, 0);
     xposShift = rAbsLayerCenter * (cos(theta) - 1.0);
     yposShift = rAbsLayerCenter * sin(theta);
-    G4ThreeVector myTrans = G4ThreeVector(-RmidAbsLayerX*cos(theta) + xposShift - xPadding, yposShift + yPadding, 0); 
+    G4ThreeVector myTrans = G4ThreeVector(-RmidAbsLayerX * cos(theta) + xposShift - xPadding, yposShift + yPadding, 0);
     //G4cout << " x: " << Rmid*cos(theta) << "    y: " << Rmid*sin(theta) << "   1.0*rad: " << 1.8*rad << G4endl;
-    G4RotationMatrix rotm  = G4RotationMatrix();
-    rotm.rotateZ((theta-theta2+0.01)*rad + tiltPadding);        // Added a funge increment factor 0.01
+    G4RotationMatrix rotm = G4RotationMatrix();
+    rotm.rotateZ((theta - theta2 + 0.01) * rad + tiltPadding);  // Added a funge increment factor 0.01
     //rotm.rotateZ(-(iLayer + nHcal2Layers/2+1)*0.02*rad + tiltPadding);        // Added a funge increment factor 0.01
-    G4Transform3D transform = G4Transform3D(rotm,myTrans);
-     
+    G4Transform3D transform = G4Transform3D(rotm, myTrans);
+
     G4cout << "  iLayer " << iLayer << G4endl;
 
-    new G4PVPlacement(transform,               //rotation,position
-                      logicHcal1ScintLayer,    //its logical volume
-                      "hcal1ScintLayer",       //its name
-                      logicHcalBox,            //its mother volume: logicHcal1Ab
-                      false,                   //no boolean operation
-                      LayerNum - 1,            //copy number
-                      checkOverlaps);          //checking overlaps 
+    new G4PVPlacement(transform,             //rotation,position
+                      logicHcal1ScintLayer,  //its logical volume
+                      "hcal1ScintLayer",     //its name
+                      logicHcalBox,          //its mother volume: logicHcal1Ab
+                      false,                 //no boolean operation
+                      LayerNum - 1,          //copy number
+                      checkOverlaps);        //checking overlaps
     LayerNum++;
   }
 
   return physiWorld;
 }
 
-
-
-void
-PHG4HcalPrototypeDetector::CalculateGeometry()
+void PHG4HcalPrototypeDetector::CalculateGeometry()
 {
-    return;
+  return;
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
@@ -638,7 +632,7 @@ void PHG4HcalPrototypeDetector::SetMaterial(G4String materialChoice)
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
- 
+
 void PHG4HcalPrototypeDetector::UpdateGeometry()
 {
   G4RunManager::GetRunManager()->PhysicsHasBeenModified();
@@ -650,25 +644,25 @@ void PHG4HcalPrototypeDetector::SetTiltViaNcross(const int ncross)
 {
   G4double sign = 1;
   if (ncross < 0)
-    {
-      sign = -1;
-    }
+  {
+    sign = -1;
+  }
   G4int ncr = fabs(ncross);
 
   // Determine title angle for the outer hcal
   //
-  G4double cSide = hcal2RadiusIn + hcal2ScintSizeX/2;
+  G4double cSide = hcal2RadiusIn + hcal2ScintSizeX / 2;
   G4double bSide = hcal2RadiusIn + hcal2ScintSizeX;
 
   G4double alpha = 0;
   if (ncr > 1)
-    {
-      alpha = (360. / nHcal2Layers * M_PI / 180.) * (ncr - 1) / 2.0;
-    }
+  {
+    alpha = (360. / nHcal2Layers * M_PI / 180.) * (ncr - 1) / 2.0;
+  }
   else
-    {
-      alpha = (360. / nHcal2Layers * M_PI / 180.) / 2.;
-    }
+  {
+    alpha = (360. / nHcal2Layers * M_PI / 180.) / 2.;
+  }
 
   G4double sinbSide = sin(alpha) * bSide / (sqrt(bSide * bSide + cSide * cSide - 2 * bSide * cSide * cos(alpha)));
   G4double beta = asin(sinbSide);  // This is the slat angle
@@ -677,9 +671,8 @@ void PHG4HcalPrototypeDetector::SetTiltViaNcross(const int ncross)
 
   // Determine title angle for the inner hcal
   //
-  cSide = hcal1RadiusIn + hcal1ScintSizeX/2;
+  cSide = hcal1RadiusIn + hcal1ScintSizeX / 2;
   bSide = hcal1RadiusIn + hcal1ScintSizeX;
-
 
   sinbSide = sin(alpha) * bSide / (sqrt(bSide * bSide + cSide * cSide - 2.0 * bSide * cSide * cos(alpha)));
   beta = asin(sinbSide);  // This is the slat angle
@@ -687,14 +680,13 @@ void PHG4HcalPrototypeDetector::SetTiltViaNcross(const int ncross)
   hcal1TiltAngle = beta * sign;
 
   G4cout << " alpha : " << alpha << G4endl;
-  G4cout <<  " SetTitlViaNCross(" << ncross << ") setting the outer hcal slat tilt angle to : " << hcal2TiltAngle << " radian" << G4endl;
-  G4cout <<  " SetTitlViaNCross(" << ncross << ") setting the inner hcal slat tilt angle to : " << hcal1TiltAngle << " radian" << G4endl;
+  G4cout << " SetTitlViaNCross(" << ncross << ") setting the outer hcal slat tilt angle to : " << hcal2TiltAngle << " radian" << G4endl;
+  G4cout << " SetTitlViaNCross(" << ncross << ") setting the inner hcal slat tilt angle to : " << hcal1TiltAngle << " radian" << G4endl;
   return;
-
 }
 
 // Detector construction messengers for setting plate angles
-// 
+//
 void PHG4HcalPrototypeDetector::SetOuterHcalDPhi(G4double dphi)
 {
   hcal2DPhi = dphi;
@@ -718,5 +710,3 @@ void PHG4HcalPrototypeDetector::SetInnerPlateTiltAngle(G4double dtheta)
   hcal1TiltAngle = dtheta;
   G4cout << "In SetInnerPlateTiltAngle: " << hcal1TiltAngle << " is set!!! " << G4endl;
 }
-
-

--- a/simulation/g4simulation/g4caloprototype/PHG4HcalPrototypeDetector.cc
+++ b/simulation/g4simulation/g4caloprototype/PHG4HcalPrototypeDetector.cc
@@ -20,6 +20,7 @@
 #include <Geant4/G4NistManager.hh>
 #include <Geant4/G4RotationMatrix.hh>            // for G4RotationMatrix
 #include <Geant4/G4RunManager.hh>
+#include <Geant4/G4String.hh>                    // for G4String
 #include <Geant4/G4SystemOfUnits.hh>             // for cm, mm, deg, rad
 #include <Geant4/G4ThreeVector.hh>               // for G4ThreeVector
 #include <Geant4/G4Transform3D.hh>               // for G4Transform3D
@@ -35,8 +36,8 @@ using namespace std;
 
 // static double no_overlap = 0.00015 * cm; // added safety margin against overlaps by using same boundary between volumes
 
-PHG4HcalPrototypeDetector::PHG4HcalPrototypeDetector( PHCompositeNode *Node, const std::string &dnam, const int lyr  ):
-  PHG4Detector(Node, dnam),
+PHG4HcalPrototypeDetector::PHG4HcalPrototypeDetector(PHG4Subsystem* subsys, PHCompositeNode *Node, const std::string &dnam, const int lyr  ):
+  PHG4Detector(subsys, Node, dnam),
   nScint360(15),  // This is legacy variable in case one wants to build a cylindrical calorimeter 
   nHcal1Layers(16),
   nHcal2Layers(nHcal1Layers),
@@ -103,7 +104,7 @@ PHG4HcalPrototypeDetector::IsInHcalPrototype(G4VPhysicalVolume * volume) const
   return 0;  // not sure what value to return for now.
 }
 
-void PHG4HcalPrototypeDetector::Construct( G4LogicalVolume* world )
+void PHG4HcalPrototypeDetector::ConstructMe( G4LogicalVolume* world )
 {
   logicWorld = world;
 

--- a/simulation/g4simulation/g4caloprototype/PHG4HcalPrototypeDetector.h
+++ b/simulation/g4simulation/g4caloprototype/PHG4HcalPrototypeDetector.h
@@ -21,6 +21,7 @@ class G4Material;
 class G4PVPlacement;
 class G4VPhysicalVolume;
 class PHCompositeNode;
+class PHG4Subsystem;
 class PHG4HcalPrototypeDetectorMessenger;
 
 class PHG4HcalPrototypeDetector: public PHG4Detector
@@ -29,14 +30,14 @@ class PHG4HcalPrototypeDetector: public PHG4Detector
   public:
 
   //! constructor
-  PHG4HcalPrototypeDetector( PHCompositeNode *Node, const std::string &dnam="HCAL", const int lyr = 0 );
+  PHG4HcalPrototypeDetector(PHG4Subsystem* subsys, PHCompositeNode *Node, const std::string &dnam, const int lyr = 0 );
 
   //! destructor
   virtual ~PHG4HcalPrototypeDetector( void )
   {}
 
   //! construct
-  virtual void Construct( G4LogicalVolume* world );
+  virtual void ConstructMe( G4LogicalVolume* world );
 
   //!@name volume accessors
   //@{

--- a/simulation/g4simulation/g4caloprototype/PHG4HcalPrototypeDetector.h
+++ b/simulation/g4simulation/g4caloprototype/PHG4HcalPrototypeDetector.h
@@ -9,11 +9,11 @@
 
 #include <g4main/PHG4Detector.h>
 
-#include <Geant4/G4String.hh>           // for G4String
+#include <Geant4/G4String.hh>  // for G4String
 #include <Geant4/G4SystemOfUnits.hh>
 #include <Geant4/G4Types.hh>
 
-#include <string>                       // for string
+#include <string>  // for string
 
 class G4Box;
 class G4LogicalVolume;
@@ -24,20 +24,19 @@ class PHCompositeNode;
 class PHG4Subsystem;
 class PHG4HcalPrototypeDetectorMessenger;
 
-class PHG4HcalPrototypeDetector: public PHG4Detector
+class PHG4HcalPrototypeDetector : public PHG4Detector
 {
-
-  public:
-
+ public:
   //! constructor
-  PHG4HcalPrototypeDetector(PHG4Subsystem* subsys, PHCompositeNode *Node, const std::string &dnam, const int lyr = 0 );
+  PHG4HcalPrototypeDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, const std::string& dnam, const int lyr = 0);
 
   //! destructor
-  virtual ~PHG4HcalPrototypeDetector( void )
-  {}
+  virtual ~PHG4HcalPrototypeDetector(void)
+  {
+  }
 
   //! construct
-  virtual void ConstructMe( G4LogicalVolume* world );
+  virtual void ConstructMe(G4LogicalVolume* world);
 
   //!@name volume accessors
   //@{
@@ -45,42 +44,39 @@ class PHG4HcalPrototypeDetector: public PHG4Detector
   //@}
 
   // We will keep these functions for now and deal with them later
-  void SetYRot(const G4double angle) {hcalBoxRotationAngle_z = angle*rad;}
-  void SetZRot(const G4double angle) {hcalBoxRotationAngle_y = angle*rad;}
-  void SetActive(const int i = 1) {active = i;}
-  void SetAbsorberActive(const int i = 1) {absorberactive = i;}
-  int IsActive() const {return active;}
-  void SuperDetector(const std::string &name) {superdetector = name;}
-  const std::string SuperDetector() const {return superdetector;}
-  int get_Layer() const {return layer;}
+  void SetYRot(const G4double angle) { hcalBoxRotationAngle_z = angle * rad; }
+  void SetZRot(const G4double angle) { hcalBoxRotationAngle_y = angle * rad; }
+  void SetActive(const int i = 1) { active = i; }
+  void SetAbsorberActive(const int i = 1) { absorberactive = i; }
+  int IsActive() const { return active; }
+  void SuperDetector(const std::string& name) { superdetector = name; }
+  const std::string SuperDetector() const { return superdetector; }
+  int get_Layer() const { return layer; }
 
-  void BlackHole(const int i=1) {blackhole = i;}
-  int IsBlackHole() const {return blackhole;}
+  void BlackHole(const int i = 1) { blackhole = i; }
+  int IsBlackHole() const { return blackhole; }
 
   // These functions are copied from our standalone simulation
-  void SetMaterial (G4String);            
+  void SetMaterial(G4String);
   void SetOuterHcalDPhi(G4double);
   void SetInnerHcalDPhi(G4double);
   void SetOuterPlateTiltAngle(G4double);
   void SetInnerPlateTiltAngle(G4double);
   void UpdateGeometry();
 
-  private:
-
+ private:
   void CalculateGeometry();
-
-
 
   G4int nScint360;
   G4int nHcal1Layers;
-  G4int nHcal2Layers; 
+  G4int nHcal2Layers;
 
   G4double hcal2ScintSizeX, hcal2ScintSizeY, hcal2ScintSizeZ;
   G4double hcal1ScintSizeX, hcal1ScintSizeY, hcal1ScintSizeZ;
   G4double hcal1TiltAngle;
   G4double hcal2TiltAngle;
-  G4double  hcal1DPhi;
-  G4double hcal2DPhi; 
+  G4double hcal1DPhi;
+  G4double hcal2DPhi;
 
   G4double hcal1RadiusIn;
   G4double hcal2RadiusIn;
@@ -92,30 +88,28 @@ class PHG4HcalPrototypeDetector: public PHG4Detector
 
   G4double hcal1Abs_dxa, hcal1Abs_dxb;
   G4double hcal1Abs_dya, hcal1Abs_dyb;
-  G4double hcal1Abs_dz;  
+  G4double hcal1Abs_dz;
 
   G4double hcalJunctionSizeX, hcalJunctionSizeY, hcalJunctionSizeZ;
 
-  
   G4VPhysicalVolume* physiWorld;
-  G4LogicalVolume*   logicWorld;
+  G4LogicalVolume* logicWorld;
 
-  G4LogicalVolume*   logicHcalBox;
-  G4Box*             solidHcalBox;
-  G4PVPlacement*     physiHcalBox;
-  
+  G4LogicalVolume* logicHcalBox;
+  G4Box* solidHcalBox;
+  G4PVPlacement* physiHcalBox;
 
-  G4LogicalVolume   *logicHcal2ScintLayer, *logicHcal1ScintLayer;
-  G4LogicalVolume   *logicHcal2AbsLayer, *logicHcal1AbsLayer;
+  G4LogicalVolume *logicHcal2ScintLayer, *logicHcal1ScintLayer;
+  G4LogicalVolume *logicHcal2AbsLayer, *logicHcal1AbsLayer;
 
-  G4Material        *world_mat, *steel, *scint_mat;
+  G4Material *world_mat, *steel, *scint_mat;
 
   void DefineMaterials();
-  G4VPhysicalVolume* ConstructDetector(); 
-    
+  G4VPhysicalVolume* ConstructDetector();
+
   void SetTiltViaNcross(const int ncross);
 
-  PHG4HcalPrototypeDetectorMessenger*  fDetectorMessenger;
+  PHG4HcalPrototypeDetectorMessenger* fDetectorMessenger;
 
   int active;
   int absorberactive;
@@ -123,7 +117,6 @@ class PHG4HcalPrototypeDetector: public PHG4Detector
   int blackhole;
   std::string detector_type;
   std::string superdetector;
-  
 };
 
 #endif

--- a/simulation/g4simulation/g4caloprototype/PHG4HcalPrototypeDetectorMessenger.cc
+++ b/simulation/g4simulation/g4caloprototype/PHG4HcalPrototypeDetectorMessenger.cc
@@ -6,62 +6,62 @@
 
 #include "PHG4HcalPrototypeDetector.h"
 
-#include <Geant4/G4ApplicationState.hh>         // for G4State_Idle, G4State...
-#include <Geant4/G4String.hh>                    // for G4String
-#include <Geant4/G4UIdirectory.hh>
-#include <Geant4/G4UIcmdWithAString.hh>
+#include <Geant4/G4ApplicationState.hh>  // for G4State_Idle, G4State...
+#include <Geant4/G4String.hh>            // for G4String
 #include <Geant4/G4UIcmdWithADoubleAndUnit.hh>
+#include <Geant4/G4UIcmdWithAString.hh>
 #include <Geant4/G4UIcmdWithoutParameter.hh>
+#include <Geant4/G4UIdirectory.hh>
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-PHG4HcalPrototypeDetectorMessenger::PHG4HcalPrototypeDetectorMessenger(PHG4HcalPrototypeDetector * Det)
-:fPHG4HcalPrototypeDetector(Det)
-{ 
+PHG4HcalPrototypeDetectorMessenger::PHG4HcalPrototypeDetectorMessenger(PHG4HcalPrototypeDetector* Det)
+  : fPHG4HcalPrototypeDetector(Det)
+{
   sPhnxDir = new G4UIdirectory("/sPhnx/");
   sPhnxDir->SetGuidance("UI commands for modifying the prototype detector properties.");
 
   detDir = new G4UIdirectory("/sPhnx/det/");
   detDir->SetGuidance("UI commands for changing the detector geometry.");
 
-  fMaterCmd = new G4UIcmdWithAString("/sPhnx/det/setMat",this);
+  fMaterCmd = new G4UIcmdWithAString("/sPhnx/det/setMat", this);
   fMaterCmd->SetGuidance("Select material of the world.");
-  fMaterCmd->SetParameterName("choice",false);
-  fMaterCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
-       
-  fUpdateCmd = new G4UIcmdWithoutParameter("/sPhnx/det/update",this);
+  fMaterCmd->SetParameterName("choice", false);
+  fMaterCmd->AvailableForStates(G4State_PreInit, G4State_Idle);
+
+  fUpdateCmd = new G4UIcmdWithoutParameter("/sPhnx/det/update", this);
   fUpdateCmd->SetGuidance("Update geometry.");
   fUpdateCmd->SetGuidance("This command MUST be applied before \"beamOn\" ");
   fUpdateCmd->SetGuidance("if you changed geometrical value(s).");
   fUpdateCmd->AvailableForStates(G4State_Idle);
 
-  outerHcalDPhiCmd = new G4UIcmdWithADoubleAndUnit("/sPhnx/det/setOuterHcalAngularSpan",this);  
+  outerHcalDPhiCmd = new G4UIcmdWithADoubleAndUnit("/sPhnx/det/setOuterHcalAngularSpan", this);
   outerHcalDPhiCmd->SetGuidance("Change the outer hcal angular span (default: 0.28 rad).");
   outerHcalDPhiCmd->SetGuidance("Need to run the detector update command after running this command!");
-  outerHcalDPhiCmd->SetParameterName("hcal2DPhi",false);
+  outerHcalDPhiCmd->SetParameterName("hcal2DPhi", false);
   outerHcalDPhiCmd->SetUnitCategory("radian");
-  outerHcalDPhiCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
+  outerHcalDPhiCmd->AvailableForStates(G4State_PreInit, G4State_Idle);
 
-  outerPlateTiltAngleCmd = new G4UIcmdWithADoubleAndUnit("/sPhnx/det/setOuterPlateTiltAngule",this);  
+  outerPlateTiltAngleCmd = new G4UIcmdWithADoubleAndUnit("/sPhnx/det/setOuterPlateTiltAngule", this);
   outerPlateTiltAngleCmd->SetGuidance("Change the outer plate tilt angle (default: 0.12 rad).");
   outerPlateTiltAngleCmd->SetGuidance("Need to run the detector update command after running this command!");
-  outerPlateTiltAngleCmd->SetParameterName("hcal2TiltAngle",false);
+  outerPlateTiltAngleCmd->SetParameterName("hcal2TiltAngle", false);
   outerPlateTiltAngleCmd->SetUnitCategory("radian");
-  outerPlateTiltAngleCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
+  outerPlateTiltAngleCmd->AvailableForStates(G4State_PreInit, G4State_Idle);
 
-  innerHcalDPhiCmd = new G4UIcmdWithADoubleAndUnit("/sPhnx/det/setInnerHcalAngularSpan",this);  
+  innerHcalDPhiCmd = new G4UIcmdWithADoubleAndUnit("/sPhnx/det/setInnerHcalAngularSpan", this);
   innerHcalDPhiCmd->SetGuidance("Change the inner hcal angular span (default: 0.28 rad).");
   innerHcalDPhiCmd->SetGuidance("Need to run the detector update command after running this command!");
-  innerHcalDPhiCmd->SetParameterName("hcal1DPhi",false);
+  innerHcalDPhiCmd->SetParameterName("hcal1DPhi", false);
   innerHcalDPhiCmd->SetUnitCategory("radian");
-  innerHcalDPhiCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
+  innerHcalDPhiCmd->AvailableForStates(G4State_PreInit, G4State_Idle);
 
-  innerPlateTiltAngleCmd = new G4UIcmdWithADoubleAndUnit("/sPhnx/det/setInnerPlateTiltAngule",this);  
+  innerPlateTiltAngleCmd = new G4UIcmdWithADoubleAndUnit("/sPhnx/det/setInnerPlateTiltAngule", this);
   innerPlateTiltAngleCmd->SetGuidance("Change the inner plate tilt angle (default: 0.30 rad).");
   innerPlateTiltAngleCmd->SetGuidance("Need to run the detector update command after running this command!");
-  innerPlateTiltAngleCmd->SetParameterName("hcal1TiltAngle",false);
+  innerPlateTiltAngleCmd->SetParameterName("hcal1TiltAngle", false);
   innerPlateTiltAngleCmd->SetUnitCategory("radian");
-  innerPlateTiltAngleCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
+  innerPlateTiltAngleCmd->AvailableForStates(G4State_PreInit, G4State_Idle);
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
@@ -78,25 +78,37 @@ PHG4HcalPrototypeDetectorMessenger::~PHG4HcalPrototypeDetectorMessenger()
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-void PHG4HcalPrototypeDetectorMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
-{ 
-  if( command == fMaterCmd )
-   { fPHG4HcalPrototypeDetector->SetMaterial(newValue);}
-   
-  if( command == fUpdateCmd )
-   { fPHG4HcalPrototypeDetector->UpdateGeometry();}
+void PHG4HcalPrototypeDetectorMessenger::SetNewValue(G4UIcommand* command, G4String newValue)
+{
+  if (command == fMaterCmd)
+  {
+    fPHG4HcalPrototypeDetector->SetMaterial(newValue);
+  }
 
-  if ( command == outerHcalDPhiCmd )
-    { fPHG4HcalPrototypeDetector->SetOuterHcalDPhi(outerHcalDPhiCmd->GetNewDoubleValue(newValue));}
+  if (command == fUpdateCmd)
+  {
+    fPHG4HcalPrototypeDetector->UpdateGeometry();
+  }
 
-  if ( command == outerPlateTiltAngleCmd )
-    { fPHG4HcalPrototypeDetector->SetOuterPlateTiltAngle(outerPlateTiltAngleCmd->GetNewDoubleValue(newValue));}
+  if (command == outerHcalDPhiCmd)
+  {
+    fPHG4HcalPrototypeDetector->SetOuterHcalDPhi(outerHcalDPhiCmd->GetNewDoubleValue(newValue));
+  }
 
-  if ( command == innerHcalDPhiCmd )
-    { fPHG4HcalPrototypeDetector->SetInnerHcalDPhi(innerHcalDPhiCmd->GetNewDoubleValue(newValue));}
+  if (command == outerPlateTiltAngleCmd)
+  {
+    fPHG4HcalPrototypeDetector->SetOuterPlateTiltAngle(outerPlateTiltAngleCmd->GetNewDoubleValue(newValue));
+  }
 
-  if ( command == innerPlateTiltAngleCmd )
-    { fPHG4HcalPrototypeDetector->SetInnerPlateTiltAngle(innerPlateTiltAngleCmd->GetNewDoubleValue(newValue));}
+  if (command == innerHcalDPhiCmd)
+  {
+    fPHG4HcalPrototypeDetector->SetInnerHcalDPhi(innerHcalDPhiCmd->GetNewDoubleValue(newValue));
+  }
+
+  if (command == innerPlateTiltAngleCmd)
+  {
+    fPHG4HcalPrototypeDetector->SetInnerPlateTiltAngle(innerPlateTiltAngleCmd->GetNewDoubleValue(newValue));
+  }
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/simulation/g4simulation/g4caloprototype/PHG4HcalPrototypeDetectorMessenger.cc
+++ b/simulation/g4simulation/g4caloprototype/PHG4HcalPrototypeDetectorMessenger.cc
@@ -7,6 +7,7 @@
 #include "PHG4HcalPrototypeDetector.h"
 
 #include <Geant4/G4ApplicationState.hh>         // for G4State_Idle, G4State...
+#include <Geant4/G4String.hh>                    // for G4String
 #include <Geant4/G4UIdirectory.hh>
 #include <Geant4/G4UIcmdWithAString.hh>
 #include <Geant4/G4UIcmdWithADoubleAndUnit.hh>

--- a/simulation/g4simulation/g4caloprototype/PHG4HcalPrototypeSteppingAction.cc
+++ b/simulation/g4simulation/g4caloprototype/PHG4HcalPrototypeSteppingAction.cc
@@ -29,6 +29,7 @@
 #include <Geant4/G4VUserTrackInformation.hh>   // for G4VUserTrackInformation
 
 #include <iostream>
+#include <string>                              // for operator+, string, ope...
 
 class PHCompositeNode;
 

--- a/simulation/g4simulation/g4caloprototype/PHG4HcalPrototypeSteppingAction.cc
+++ b/simulation/g4simulation/g4caloprototype/PHG4HcalPrototypeSteppingAction.cc
@@ -4,8 +4,8 @@
 #include "PHG4HcalPrototypeSteppingAction.h"
 #include "PHG4HcalPrototypeDetector.h"
 
-#include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hit.h>
+#include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hitv1.h>
 #include <g4main/PHG4Shower.h>
 #include <g4main/PHG4TrackUserInfoV1.h>
@@ -15,38 +15,38 @@
 #include <Geant4/G4ParticleDefinition.hh>      // for G4ParticleDefinition
 #include <Geant4/G4ReferenceCountedHandle.hh>  // for G4ReferenceCountedHandle
 #include <Geant4/G4Step.hh>
-#include <Geant4/G4StepPoint.hh>               // for G4StepPoint
-#include <Geant4/G4StepStatus.hh>              // for fGeomBoundary, fUndefined
-#include <Geant4/G4String.hh>                  // for G4String
-#include <Geant4/G4SystemOfUnits.hh>           // for cm, GeV, nanosecond
-#include <Geant4/G4ThreeVector.hh>             // for G4ThreeVector
-#include <Geant4/G4TouchableHandle.hh>         // for G4TouchableHandle
-#include <Geant4/G4Track.hh>                   // for G4Track
-#include <Geant4/G4TrackStatus.hh>             // for fStopAndKill
-#include <Geant4/G4Types.hh>                   // for G4int, G4double
-#include <Geant4/G4VPhysicalVolume.hh>         // for G4VPhysicalVolume
-#include <Geant4/G4VTouchable.hh>              // for G4VTouchable
-#include <Geant4/G4VUserTrackInformation.hh>   // for G4VUserTrackInformation
+#include <Geant4/G4StepPoint.hh>              // for G4StepPoint
+#include <Geant4/G4StepStatus.hh>             // for fGeomBoundary, fUndefined
+#include <Geant4/G4String.hh>                 // for G4String
+#include <Geant4/G4SystemOfUnits.hh>          // for cm, GeV, nanosecond
+#include <Geant4/G4ThreeVector.hh>            // for G4ThreeVector
+#include <Geant4/G4TouchableHandle.hh>        // for G4TouchableHandle
+#include <Geant4/G4Track.hh>                  // for G4Track
+#include <Geant4/G4TrackStatus.hh>            // for fStopAndKill
+#include <Geant4/G4Types.hh>                  // for G4int, G4double
+#include <Geant4/G4VPhysicalVolume.hh>        // for G4VPhysicalVolume
+#include <Geant4/G4VTouchable.hh>             // for G4VTouchable
+#include <Geant4/G4VUserTrackInformation.hh>  // for G4VUserTrackInformation
 
 #include <iostream>
-#include <string>                              // for operator+, string, ope...
+#include <string>  // for operator+, string, ope...
 
 class PHCompositeNode;
 
 using namespace std;
 //____________________________________________________________________________..
-PHG4HcalPrototypeSteppingAction::PHG4HcalPrototypeSteppingAction( PHG4HcalPrototypeDetector* detector ):
-  PHG4SteppingAction(detector->GetName()),
-  detector_( detector ),
-  hits_(nullptr),
-  absorberhits_(nullptr),
-  hit(nullptr)
-{}
+PHG4HcalPrototypeSteppingAction::PHG4HcalPrototypeSteppingAction(PHG4HcalPrototypeDetector* detector)
+  : PHG4SteppingAction(detector->GetName())
+  , detector_(detector)
+  , hits_(nullptr)
+  , absorberhits_(nullptr)
+  , hit(nullptr)
+{
+}
 
 //____________________________________________________________________________..
-bool PHG4HcalPrototypeSteppingAction::UserSteppingAction( const G4Step* aStep, bool )
+bool PHG4HcalPrototypeSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
 {
-
   G4TouchableHandle touch = aStep->GetPreStepPoint()->GetTouchableHandle();
   // get volume of the current step
   G4VPhysicalVolume* volume = touch->GetVolume();
@@ -63,230 +63,227 @@ bool PHG4HcalPrototypeSteppingAction::UserSteppingAction( const G4Step* aStep, b
 
   // collect energy and track length step by step
   G4double edep = aStep->GetTotalEnergyDeposit() / GeV;
-  G4double eion = (aStep->GetTotalEnergyDeposit()-aStep->GetNonIonizingEnergyDeposit()) / GeV;
+  G4double eion = (aStep->GetTotalEnergyDeposit() - aStep->GetNonIonizingEnergyDeposit()) / GeV;
 
   const G4Track* aTrack = aStep->GetTrack();
 
   // if this block stops everything, just put all kinetic energy into edep
   if (detector_->IsBlackHole())
-    {
-      edep = aTrack->GetKineticEnergy() / GeV;
-      G4Track* killtrack = const_cast<G4Track *> (aTrack);
-      killtrack->SetTrackStatus(fStopAndKill);
-    }
+  {
+    edep = aTrack->GetKineticEnergy() / GeV;
+    G4Track* killtrack = const_cast<G4Track*>(aTrack);
+    killtrack->SetTrackStatus(fStopAndKill);
+  }
 
   // Add detector element ID into to the hit
 
   G4int scintSheetCopyNumber, scintSheetLayerNumber;
-  
+
   G4int sectionID = 0;
   G4int scintID = 0x0;
   //  G4int absID = 0;
-  
+
   if (volume->GetName() == "hcal1AbsLayer")
-    {
-      sectionID = 1;
-      //      absID = volume->GetCopyNo()+100;   // Inner section absorber layer ID's are 100, 101, ..., 115
-      scintID = -1;                      // scintID is not valid, we set it to -1
-    }
+  {
+    sectionID = 1;
+    //      absID = volume->GetCopyNo()+100;   // Inner section absorber layer ID's are 100, 101, ..., 115
+    scintID = -1;  // scintID is not valid, we set it to -1
+  }
   else if (volume->GetName() == "hcal2AbsLayer")
-    {
-      sectionID = 2;
-      //      absID = volume->GetCopyNo()+200;   // Outer section absorber layer ID's are 200, 201, ..., 215
-      scintID = -1;                      // scintID is not valid, we set it to -1
-    }
+  {
+    sectionID = 2;
+    //      absID = volume->GetCopyNo()+200;   // Outer section absorber layer ID's are 200, 201, ..., 215
+    scintID = -1;  // scintID is not valid, we set it to -1
+  }
   else if (volume->GetName() == "inner1USheet")
-    {
-      sectionID = 1;
-      scintSheetCopyNumber = volume->GetCopyNo();   // either 1 or 0
-      scintSheetLayerNumber = aStep->GetPreStepPoint()->GetTouchableHandle()->GetVolume(1)->GetCopyNo();
-      scintID = (scintSheetLayerNumber << 2) + (1 << 1) + scintSheetCopyNumber;
-      //      absID = -1;                        // absID is not valid, we set it to -1
-      //G4cout << " **************** scintID: " << scintID << G4endl;
-    }
+  {
+    sectionID = 1;
+    scintSheetCopyNumber = volume->GetCopyNo();  // either 1 or 0
+    scintSheetLayerNumber = aStep->GetPreStepPoint()->GetTouchableHandle()->GetVolume(1)->GetCopyNo();
+    scintID = (scintSheetLayerNumber << 2) + (1 << 1) + scintSheetCopyNumber;
+    //      absID = -1;                        // absID is not valid, we set it to -1
+    //G4cout << " **************** scintID: " << scintID << G4endl;
+  }
   else if (volume->GetName() == "inner2USheet")
-    {
-      sectionID = 1;
-      scintSheetCopyNumber = volume->GetCopyNo();   // either 1 or 0
-      scintSheetLayerNumber = aStep->GetPreStepPoint()->GetTouchableHandle()->GetVolume(1)->GetCopyNo();
-      scintID = (scintSheetLayerNumber << 2) + (0 << 1) + scintSheetCopyNumber;
-      //      absID = -1;                        // absID is not valid, we set it to -1
-      //G4cout << " **************** scintID: " << scintID << G4endl;
-    }
+  {
+    sectionID = 1;
+    scintSheetCopyNumber = volume->GetCopyNo();  // either 1 or 0
+    scintSheetLayerNumber = aStep->GetPreStepPoint()->GetTouchableHandle()->GetVolume(1)->GetCopyNo();
+    scintID = (scintSheetLayerNumber << 2) + (0 << 1) + scintSheetCopyNumber;
+    //      absID = -1;                        // absID is not valid, we set it to -1
+    //G4cout << " **************** scintID: " << scintID << G4endl;
+  }
   else if (volume->GetName() == "outer1USheet")
-    {
-      sectionID = 2;
-      scintSheetCopyNumber = volume->GetCopyNo();   // either 1 or 0
-      scintSheetLayerNumber = aStep->GetPreStepPoint()->GetTouchableHandle()->GetVolume(1)->GetCopyNo();
-      scintID = (scintSheetLayerNumber << 2) + (1 << 1) + scintSheetCopyNumber;
-      //      absID = -1;                        // absID is not valid, we set it to -1
-      //G4cout << " **************** scintID: " << scintID << G4endl;
-    }
+  {
+    sectionID = 2;
+    scintSheetCopyNumber = volume->GetCopyNo();  // either 1 or 0
+    scintSheetLayerNumber = aStep->GetPreStepPoint()->GetTouchableHandle()->GetVolume(1)->GetCopyNo();
+    scintID = (scintSheetLayerNumber << 2) + (1 << 1) + scintSheetCopyNumber;
+    //      absID = -1;                        // absID is not valid, we set it to -1
+    //G4cout << " **************** scintID: " << scintID << G4endl;
+  }
   else if (volume->GetName() == "outer2USheet")
-    {
-      sectionID = 2;
-      scintSheetCopyNumber = volume->GetCopyNo();   // either 1 or 0
-      scintSheetLayerNumber = aStep->GetPreStepPoint()->GetTouchableHandle()->GetVolume(1)->GetCopyNo();
-      scintID = (scintSheetLayerNumber << 2) + (0 << 1) + scintSheetCopyNumber;
-      //      absID = -1;                        // absID is not valid, we set it to -1
-      //G4cout << " **************** scintID: " << scintID << G4endl;
-    }
-  else {
+  {
+    sectionID = 2;
+    scintSheetCopyNumber = volume->GetCopyNo();  // either 1 or 0
+    scintSheetLayerNumber = aStep->GetPreStepPoint()->GetTouchableHandle()->GetVolume(1)->GetCopyNo();
+    scintID = (scintSheetLayerNumber << 2) + (0 << 1) + scintSheetCopyNumber;
+    //      absID = -1;                        // absID is not valid, we set it to -1
+    //G4cout << " **************** scintID: " << scintID << G4endl;
+  }
+  else
+  {
     return false;
   }
-  
+
   // make sure we are in a volume
-  if ( detector_->IsActive() )
+  if (detector_->IsActive())
+  {
+    bool geantino = false;
+    // the check for the pdg code speeds things up, I do not want to make
+    // an expensive string compare for every track when we know
+    // geantino or chargedgeantino has pid=0
+    if (aTrack->GetParticleDefinition()->GetPDGEncoding() == 0 &&
+        aTrack->GetParticleDefinition()->GetParticleName().find("geantino") != string::npos)
     {
-      bool geantino = false;
-      // the check for the pdg code speeds things up, I do not want to make
-      // an expensive string compare for every track when we know
-      // geantino or chargedgeantino has pid=0
-      if (aTrack->GetParticleDefinition()->GetPDGEncoding() == 0 &&
-	  aTrack->GetParticleDefinition()->GetParticleName().find("geantino") != string::npos)
-	{
-	  geantino = true;
-	}
-
-      G4StepPoint * prePoint = aStep->GetPreStepPoint();
-      G4StepPoint * postPoint = aStep->GetPostStepPoint();
-      //       cout << "track id " << aTrack->GetTrackID() << endl;
-      //       cout << "time prepoint: " << prePoint->GetGlobalTime() << endl;
-      //       cout << "time postpoint: " << postPoint->GetGlobalTime() << endl;
-      switch (prePoint->GetStepStatus())
-	{
-	case fGeomBoundary:
-	case fUndefined:
-	  hit = new PHG4Hitv1();
-	  hit->set_layer((unsigned int)sectionID);
-	  hit->set_scint_id(scintID); 
-	  //here we set the entrance values in cm
-	  hit->set_x( 0, prePoint->GetPosition().x() / cm);
-	  hit->set_y( 0, prePoint->GetPosition().y() / cm );
-	  hit->set_z( 0, prePoint->GetPosition().z() / cm );
-	  // time in ns
-	  hit->set_t( 0, prePoint->GetGlobalTime() / nanosecond );
-	  //set the track ID
-	  {
-            hit->set_trkid(aTrack->GetTrackID());
-            if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
-	      {
-		if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
-		  {
-		    hit->set_trkid(pp->GetUserTrackId());
-		    hit->set_shower_id(pp->GetShower()->get_id());
-		  }
-	      }
-	  }
-	  
-	  //set the initial energy deposit
-	  hit->set_edep(0);
-	  hit->set_eion(0);
-	  if (scintID > 0) // return of isinHcalTestDetector, > 0 hit in scintillator, < 0 hit in absorber
-	    {
-	      // Now add the hit
-	      hits_->AddHit(sectionID, hit);
-	      
-	      {
-		if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
-		  {
-		    if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
-		      {
-			pp->GetShower()->add_g4hit_id(hits_->GetID(),hit->get_hit_id());
-		      }
-		  }
-	      }
-	    }
-	  else
-	    {
-	      absorberhits_->AddHit(sectionID, hit);
-
-	      {
-		if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
-		  {
-		    if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
-		      {
-			pp->GetShower()->add_g4hit_id(absorberhits_->GetID(),hit->get_hit_id());
-		      }
-		  }
-	      }
-	    }
-	  break;
-	default:
-	  break;
-	}
-
-      // here we just update the exit values, it will be overwritten
-      // for every step until we leave the volume or the particle
-      // ceases to exist
-      hit->set_x( 1, postPoint->GetPosition().x() / cm );
-      hit->set_y( 1, postPoint->GetPosition().y() / cm );
-      hit->set_z( 1, postPoint->GetPosition().z() / cm );
-
-      hit->set_t( 1, postPoint->GetGlobalTime() / nanosecond );
-      //sum up the energy to get total deposited
-      hit->set_edep(hit->get_edep() + edep);
-      hit->set_eion(hit->get_eion() + eion);
-      if (geantino)
-	{
-	  hit->set_edep(-1); // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression
-          hit->set_eion(-1);
-	}
-      if (edep > 0)
-	{
-	  if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
-	    {
-	      if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
-		{
-		  pp->SetKeep(1); // we want to keep the track
-		}
-
-
-	    }
-	}
-
-      //       hit->identify();
-      // return true to indicate the hit was used
-      return true;
-
+      geantino = true;
     }
+
+    G4StepPoint* prePoint = aStep->GetPreStepPoint();
+    G4StepPoint* postPoint = aStep->GetPostStepPoint();
+    //       cout << "track id " << aTrack->GetTrackID() << endl;
+    //       cout << "time prepoint: " << prePoint->GetGlobalTime() << endl;
+    //       cout << "time postpoint: " << postPoint->GetGlobalTime() << endl;
+    switch (prePoint->GetStepStatus())
+    {
+    case fGeomBoundary:
+    case fUndefined:
+      hit = new PHG4Hitv1();
+      hit->set_layer((unsigned int) sectionID);
+      hit->set_scint_id(scintID);
+      //here we set the entrance values in cm
+      hit->set_x(0, prePoint->GetPosition().x() / cm);
+      hit->set_y(0, prePoint->GetPosition().y() / cm);
+      hit->set_z(0, prePoint->GetPosition().z() / cm);
+      // time in ns
+      hit->set_t(0, prePoint->GetGlobalTime() / nanosecond);
+      //set the track ID
+      {
+        hit->set_trkid(aTrack->GetTrackID());
+        if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
+        {
+          if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
+          {
+            hit->set_trkid(pp->GetUserTrackId());
+            hit->set_shower_id(pp->GetShower()->get_id());
+          }
+        }
+      }
+
+      //set the initial energy deposit
+      hit->set_edep(0);
+      hit->set_eion(0);
+      if (scintID > 0)  // return of isinHcalTestDetector, > 0 hit in scintillator, < 0 hit in absorber
+      {
+        // Now add the hit
+        hits_->AddHit(sectionID, hit);
+
+        {
+          if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
+          {
+            if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
+            {
+              pp->GetShower()->add_g4hit_id(hits_->GetID(), hit->get_hit_id());
+            }
+          }
+        }
+      }
+      else
+      {
+        absorberhits_->AddHit(sectionID, hit);
+
+        {
+          if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
+          {
+            if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
+            {
+              pp->GetShower()->add_g4hit_id(absorberhits_->GetID(), hit->get_hit_id());
+            }
+          }
+        }
+      }
+      break;
+    default:
+      break;
+    }
+
+    // here we just update the exit values, it will be overwritten
+    // for every step until we leave the volume or the particle
+    // ceases to exist
+    hit->set_x(1, postPoint->GetPosition().x() / cm);
+    hit->set_y(1, postPoint->GetPosition().y() / cm);
+    hit->set_z(1, postPoint->GetPosition().z() / cm);
+
+    hit->set_t(1, postPoint->GetGlobalTime() / nanosecond);
+    //sum up the energy to get total deposited
+    hit->set_edep(hit->get_edep() + edep);
+    hit->set_eion(hit->get_eion() + eion);
+    if (geantino)
+    {
+      hit->set_edep(-1);  // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression
+      hit->set_eion(-1);
+    }
+    if (edep > 0)
+    {
+      if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
+      {
+        if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
+        {
+          pp->SetKeep(1);  // we want to keep the track
+        }
+      }
+    }
+
+    //       hit->identify();
+    // return true to indicate the hit was used
+    return true;
+  }
   else
-    {
-      return false;
-    }
+  {
+    return false;
+  }
 }
 
 //____________________________________________________________________________..
-void PHG4HcalPrototypeSteppingAction::SetInterfacePointers( PHCompositeNode* topNode )
+void PHG4HcalPrototypeSteppingAction::SetInterfacePointers(PHCompositeNode* topNode)
 {
-
   string hitnodename;
   string absorbernodename;
   if (detector_->SuperDetector() != "NONE")
-    {
-      hitnodename = "G4HIT_" + detector_->SuperDetector();
-      absorbernodename =  "G4HIT_ABSORBER_" + detector_->SuperDetector();
-    }
+  {
+    hitnodename = "G4HIT_" + detector_->SuperDetector();
+    absorbernodename = "G4HIT_ABSORBER_" + detector_->SuperDetector();
+  }
   else
-    {
-      hitnodename = "G4HIT_" + detector_->GetName();
-      absorbernodename =  "G4HIT_ABSORBER_" + detector_->GetName();
-    }
+  {
+    hitnodename = "G4HIT_" + detector_->GetName();
+    absorbernodename = "G4HIT_ABSORBER_" + detector_->GetName();
+  }
 
   //now look for the map and grab a pointer to it.
-  hits_ =  findNode::getClass<PHG4HitContainer>( topNode , hitnodename.c_str() );
-  absorberhits_ =  findNode::getClass<PHG4HitContainer>( topNode , absorbernodename.c_str() );
+  hits_ = findNode::getClass<PHG4HitContainer>(topNode, hitnodename.c_str());
+  absorberhits_ = findNode::getClass<PHG4HitContainer>(topNode, absorbernodename.c_str());
 
   // if we do not find the node it's messed up.
-  if ( ! hits_ )
+  if (!hits_)
+  {
+    std::cout << "PHG4HcalPrototypeSteppingAction::SetTopNode - unable to find " << hitnodename << std::endl;
+  }
+  if (!absorberhits_)
+  {
+    if (Verbosity() > 0)
     {
-      std::cout << "PHG4HcalPrototypeSteppingAction::SetTopNode - unable to find " << hitnodename << std::endl;
+      cout << "PHG4HcalSteppingAction::SetTopNode - unable to find " << absorbernodename << endl;
     }
-  if ( ! absorberhits_)
-    {
-      if (Verbosity() > 0)
-	{
-	  cout << "PHG4HcalSteppingAction::SetTopNode - unable to find " << absorbernodename << endl;
-	}
-    }
+  }
 }

--- a/simulation/g4simulation/g4caloprototype/PHG4HcalPrototypeSubsystem.cc
+++ b/simulation/g4simulation/g4caloprototype/PHG4HcalPrototypeSubsystem.cc
@@ -6,7 +6,9 @@
 #include "PHG4HcalPrototypeSteppingAction.h"
 
 #include <g4detectors/PHG4EventActionClearZeroEdep.h>
+
 #include <g4main/PHG4HitContainer.h>
+#include <g4main/PHG4Subsystem.h>                      // for PHG4Subsystem
 
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>               // for PHIODataNode
@@ -57,7 +59,7 @@ int PHG4HcalPrototypeSubsystem::Init( PHCompositeNode* topNode )
   PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST" ));
 
   // create detector
-  detector_ = new PHG4HcalPrototypeDetector(topNode, Name(), layer);
+  detector_ = new PHG4HcalPrototypeDetector(this, topNode, Name(), layer);
   detector_->SetYRot(rot_in_y);
   detector_->SetZRot(rot_in_z);
   detector_->SetActive(active);

--- a/simulation/g4simulation/g4caloprototype/PHG4HcalPrototypeSubsystem.cc
+++ b/simulation/g4simulation/g4caloprototype/PHG4HcalPrototypeSubsystem.cc
@@ -8,55 +8,55 @@
 #include <g4detectors/PHG4EventActionClearZeroEdep.h>
 
 #include <g4main/PHG4HitContainer.h>
-#include <g4main/PHG4Subsystem.h>                      // for PHG4Subsystem
+#include <g4main/PHG4Subsystem.h>  // for PHG4Subsystem
 
 #include <phool/PHCompositeNode.h>
-#include <phool/PHIODataNode.h>               // for PHIODataNode
-#include <phool/PHNode.h>                     // for PHNode
-#include <phool/PHNodeIterator.h>             // for PHNodeIterator
-#include <phool/PHObject.h>                   // for PHObject
+#include <phool/PHIODataNode.h>    // for PHIODataNode
+#include <phool/PHNode.h>          // for PHNode
+#include <phool/PHNodeIterator.h>  // for PHNodeIterator
+#include <phool/PHObject.h>        // for PHObject
 #include <phool/getClass.h>
 
-#include <Geant4/G4SystemOfUnits.hh>          // for cm
-#include <Geant4/G4Types.hh>                  // for G4double
+#include <Geant4/G4SystemOfUnits.hh>  // for cm
+#include <Geant4/G4Types.hh>          // for G4double
 
 #include <sstream>
 
 using namespace std;
 
 //_______________________________________________________________________
-PHG4HcalPrototypeSubsystem::PHG4HcalPrototypeSubsystem( const std::string &name, const int lyr ):
-  PHG4Subsystem( name ),
-  detector_( 0 ),
-  steppingAction_( nullptr ),
-  eventAction_(nullptr),
-  rot_in_y(0),
-  rot_in_z(0),
-  material("G4_AIR"),  // default - almost nothing
-  active(0),
-  absorberactive(0),
-  layer(lyr),
-  blackhole(0),
-  detector_type(name),
-  superdetector("NONE")
+PHG4HcalPrototypeSubsystem::PHG4HcalPrototypeSubsystem(const std::string& name, const int lyr)
+  : PHG4Subsystem(name)
+  , detector_(0)
+  , steppingAction_(nullptr)
+  , eventAction_(nullptr)
+  , rot_in_y(0)
+  , rot_in_z(0)
+  , material("G4_AIR")
+  ,  // default - almost nothing
+  active(0)
+  , absorberactive(0)
+  , layer(lyr)
+  , blackhole(0)
+  , detector_type(name)
+  , superdetector("NONE")
 {
-
   // put the layer into the name so we get unique names
   // for multiple layers
   ostringstream nam;
   nam << name << "_" << lyr;
   Name(nam.str().c_str());
   for (int i = 0; i < 3; i++)
-    {
-      dimension[i] = 100.0 * cm;
-    }
+  {
+    dimension[i] = 100.0 * cm;
+  }
 }
 
 //_______________________________________________________________________
-int PHG4HcalPrototypeSubsystem::Init( PHCompositeNode* topNode )
+int PHG4HcalPrototypeSubsystem::Init(PHCompositeNode* topNode)
 {
-  PHNodeIterator iter( topNode );
-  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST" ));
+  PHNodeIterator iter(topNode);
+  PHCompositeNode* dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
 
   // create detector
   detector_ = new PHG4HcalPrototypeDetector(this, topNode, Name(), layer);
@@ -68,79 +68,71 @@ int PHG4HcalPrototypeSubsystem::Init( PHCompositeNode* topNode )
   detector_->SuperDetector(superdetector);
   detector_->OverlapCheck(CheckOverlap());
   if (active)
+  {
+    ostringstream nodename;
+    if (superdetector != "NONE")
     {
-      ostringstream nodename;
+      nodename << "G4HIT_" << superdetector;
+    }
+    else
+    {
+      nodename << "G4HIT_" << detector_type << "_" << layer;
+    }
+    // create hit list
+    PHG4HitContainer* block_hits = findNode::getClass<PHG4HitContainer>(topNode, nodename.str().c_str());
+    if (!block_hits)
+    {
+      dstNode->addNode(new PHIODataNode<PHObject>(block_hits = new PHG4HitContainer(nodename.str()), nodename.str().c_str(), "PHObject"));
+    }
+    if (absorberactive)
+    {
+      nodename.str("");
       if (superdetector != "NONE")
-	{
-	  nodename <<  "G4HIT_" << superdetector;
-	}
+      {
+        nodename << "G4HIT_ABSORBER_" << superdetector;
+      }
       else
-	{
-	  nodename <<  "G4HIT_" << detector_type << "_" << layer;
-	}
-      // create hit list
-      PHG4HitContainer* block_hits =  findNode::getClass<PHG4HitContainer>( topNode , nodename.str().c_str());
-      if ( !block_hits )
-	{
-
-	  dstNode->addNode( new PHIODataNode<PHObject>( block_hits = new PHG4HitContainer(nodename.str()), nodename.str().c_str(), "PHObject" ));
-
-	}
-      if (absorberactive)
-	{
-	  nodename.str("");
-	  if (superdetector != "NONE")
-	    {
-	      nodename <<  "G4HIT_ABSORBER_" << superdetector;
-	    }
-	  else
-	    {
-	      nodename <<  "G4HIT_ABSORBER_" << detector_type << "_" << layer;
-	    }
-	}
-      block_hits =  findNode::getClass<PHG4HitContainer>( topNode , nodename.str().c_str());
-      if ( !block_hits )
-	{
-
-	  dstNode->addNode( new PHIODataNode<PHObject>( block_hits = new PHG4HitContainer(nodename.str()), nodename.str().c_str(), "PHObject" ));
-
-	}
-      // create stepping action
-      steppingAction_ = new PHG4HcalPrototypeSteppingAction(detector_);
-
-      eventAction_ = new PHG4EventActionClearZeroEdep(topNode, nodename.str());
+      {
+        nodename << "G4HIT_ABSORBER_" << detector_type << "_" << layer;
+      }
     }
-  if (blackhole && !active)
+    block_hits = findNode::getClass<PHG4HitContainer>(topNode, nodename.str().c_str());
+    if (!block_hits)
     {
-      steppingAction_ = new PHG4HcalPrototypeSteppingAction(detector_);
+      dstNode->addNode(new PHIODataNode<PHObject>(block_hits = new PHG4HitContainer(nodename.str()), nodename.str().c_str(), "PHObject"));
     }
-  return 0;
+    // create stepping action
+    steppingAction_ = new PHG4HcalPrototypeSteppingAction(detector_);
 
+    eventAction_ = new PHG4EventActionClearZeroEdep(topNode, nodename.str());
+  }
+  if (blackhole && !active)
+  {
+    steppingAction_ = new PHG4HcalPrototypeSteppingAction(detector_);
+  }
+  return 0;
 }
 
 //_______________________________________________________________________
-int
-PHG4HcalPrototypeSubsystem::process_event( PHCompositeNode * topNode )
+int PHG4HcalPrototypeSubsystem::process_event(PHCompositeNode* topNode)
 {
   // pass top node to stepping action so that it gets
   // relevant nodes needed internally
-    if (steppingAction_)
-        {
-            steppingAction_->SetInterfacePointers( topNode );
-        }
-    return 0;
-}
-
-
-//_______________________________________________________________________
-PHG4Detector* PHG4HcalPrototypeSubsystem::GetDetector( void ) const
-{
-    return detector_;
+  if (steppingAction_)
+  {
+    steppingAction_->SetInterfacePointers(topNode);
+  }
+  return 0;
 }
 
 //_______________________________________________________________________
-PHG4SteppingAction* PHG4HcalPrototypeSubsystem::GetSteppingAction( void ) const
+PHG4Detector* PHG4HcalPrototypeSubsystem::GetDetector(void) const
 {
-    return steppingAction_;
+  return detector_;
 }
 
+//_______________________________________________________________________
+PHG4SteppingAction* PHG4HcalPrototypeSubsystem::GetSteppingAction(void) const
+{
+  return steppingAction_;
+}

--- a/simulation/g4simulation/g4caloprototype/PHG4Prototype2InnerHcalDetector.cc
+++ b/simulation/g4simulation/g4caloprototype/PHG4Prototype2InnerHcalDetector.cc
@@ -2,7 +2,7 @@
 
 #include <phparameter/PHParameters.h>
 
-#include <g4main/PHG4Detector.h>                   // for PHG4Detector
+#include <g4main/PHG4Detector.h>  // for PHG4Detector
 
 #include <Geant4/G4AssemblyVolume.hh>
 #include <Geant4/G4Box.hh>
@@ -12,21 +12,21 @@
 #include <Geant4/G4Material.hh>
 #include <Geant4/G4PVPlacement.hh>
 #include <Geant4/G4RotationMatrix.hh>
-#include <Geant4/G4String.hh>                      // for G4String
+#include <Geant4/G4String.hh>  // for G4String
 #include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4ThreeVector.hh>                 // for G4ThreeVector
+#include <Geant4/G4ThreeVector.hh>  // for G4ThreeVector
 #include <Geant4/G4TwoVector.hh>
+#include <Geant4/G4VPhysicalVolume.hh>  // for G4VPhysicalVolume
+#include <Geant4/G4VSolid.hh>           // for G4VSolid
 #include <Geant4/G4VisAttributes.hh>
-#include <Geant4/G4VPhysicalVolume.hh>             // for G4VPhysicalVolume
-#include <Geant4/G4VSolid.hh>                      // for G4VSolid
 
 #include <boost/format.hpp>
 
 #include <cmath>
-#include <iostream>                                // for operator<<, endl
+#include <iostream>  // for operator<<, endl
 #include <sstream>
-#include <utility>                                 // for pair, make_pair
-#include <vector>                                  // for vector, vector<>::...
+#include <utility>  // for pair, make_pair
+#include <vector>   // for vector, vector<>::...
 
 class PHCompositeNode;
 
@@ -36,7 +36,7 @@ static const string scintimothername = "InnerHcalScintiMother";
 static const string steelplatename = "InnerHcalSteelPlate";
 
 PHG4Prototype2InnerHcalDetector::PHG4Prototype2InnerHcalDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, PHParameters* parameters, const std::string& dnam)
-								 : PHG4Detector(subsys, Node, dnam)
+  : PHG4Detector(subsys, Node, dnam)
   , m_Params(parameters)
   , m_InnerHcalSteelPlate(nullptr)
   , m_InnerHcalAssembly(nullptr)

--- a/simulation/g4simulation/g4caloprototype/PHG4Prototype2InnerHcalDetector.cc
+++ b/simulation/g4simulation/g4caloprototype/PHG4Prototype2InnerHcalDetector.cc
@@ -35,8 +35,8 @@ using namespace std;
 static const string scintimothername = "InnerHcalScintiMother";
 static const string steelplatename = "InnerHcalSteelPlate";
 
-PHG4Prototype2InnerHcalDetector::PHG4Prototype2InnerHcalDetector(PHCompositeNode* Node, PHParameters* parameters, const std::string& dnam)
-  : PHG4Detector(Node, dnam)
+PHG4Prototype2InnerHcalDetector::PHG4Prototype2InnerHcalDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, PHParameters* parameters, const std::string& dnam)
+								 : PHG4Detector(subsys, Node, dnam)
   , m_Params(parameters)
   , m_InnerHcalSteelPlate(nullptr)
   , m_InnerHcalAssembly(nullptr)
@@ -389,7 +389,7 @@ PHG4Prototype2InnerHcalDetector::ConstructScintiTile12(G4LogicalVolume* hcalenve
 
 // Construct the envelope and the call the
 // actual inner hcal construction
-void PHG4Prototype2InnerHcalDetector::Construct(G4LogicalVolume* logicWorld)
+void PHG4Prototype2InnerHcalDetector::ConstructMe(G4LogicalVolume* logicWorld)
 {
   G4ThreeVector g4vec(m_Params->get_double_param("place_x") * cm,
                       m_Params->get_double_param("place_y") * cm,

--- a/simulation/g4simulation/g4caloprototype/PHG4Prototype2InnerHcalDetector.h
+++ b/simulation/g4simulation/g4caloprototype/PHG4Prototype2InnerHcalDetector.h
@@ -15,19 +15,20 @@ class G4AssemblyVolume;
 class G4LogicalVolume;
 class G4VPhysicalVolume;
 class PHCompositeNode;
+class PHG4Subsystem;
 class PHParameters;
 
 class PHG4Prototype2InnerHcalDetector : public PHG4Detector
 {
  public:
   //! constructor
-  PHG4Prototype2InnerHcalDetector(PHCompositeNode* Node, PHParameters* parameters, const std::string& dnam);
+  PHG4Prototype2InnerHcalDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, PHParameters* parameters, const std::string& dnam);
 
   //! destructor
   virtual ~PHG4Prototype2InnerHcalDetector();
 
   //! construct
-  virtual void Construct(G4LogicalVolume* world);
+  virtual void ConstructMe(G4LogicalVolume* world);
 
   virtual void Print(const std::string& what = "ALL") const;
 

--- a/simulation/g4simulation/g4caloprototype/PHG4Prototype2InnerHcalDetector.h
+++ b/simulation/g4simulation/g4caloprototype/PHG4Prototype2InnerHcalDetector.h
@@ -9,7 +9,7 @@
 
 #include <map>
 #include <set>
-#include <string>                 // for string
+#include <string>  // for string
 
 class G4AssemblyVolume;
 class G4LogicalVolume;

--- a/simulation/g4simulation/g4caloprototype/PHG4Prototype2InnerHcalSubsystem.cc
+++ b/simulation/g4simulation/g4caloprototype/PHG4Prototype2InnerHcalSubsystem.cc
@@ -5,22 +5,22 @@
 
 #include <phparameter/PHParameters.h>
 
-#include <g4detectors/PHG4DetectorSubsystem.h>      // for PHG4DetectorSubsy...
+#include <g4detectors/PHG4DetectorSubsystem.h>  // for PHG4DetectorSubsy...
 
 #include <g4main/PHG4HitContainer.h>
-#include <g4main/PHG4SteppingAction.h>              // for PHG4SteppingAction
+#include <g4main/PHG4SteppingAction.h>  // for PHG4SteppingAction
 
 #include <phool/PHCompositeNode.h>
-#include <phool/PHIODataNode.h>                     // for PHIODataNode
-#include <phool/PHNode.h>                           // for PHNode
-#include <phool/PHNodeIterator.h>                   // for PHNodeIterator
-#include <phool/PHObject.h>                         // for PHObject
+#include <phool/PHIODataNode.h>    // for PHIODataNode
+#include <phool/PHNode.h>          // for PHNode
+#include <phool/PHNodeIterator.h>  // for PHNodeIterator
+#include <phool/PHObject.h>        // for PHObject
 #include <phool/getClass.h>
 
 #include <boost/foreach.hpp>
 
-#include <cmath>                                   // for NAN
-#include <iostream>                                 // for operator<<, basic...
+#include <cmath>     // for NAN
+#include <iostream>  // for operator<<, basic...
 #include <set>
 #include <sstream>
 

--- a/simulation/g4simulation/g4caloprototype/PHG4Prototype2InnerHcalSubsystem.cc
+++ b/simulation/g4simulation/g4caloprototype/PHG4Prototype2InnerHcalSubsystem.cc
@@ -5,6 +5,8 @@
 
 #include <phparameter/PHParameters.h>
 
+#include <g4detectors/PHG4DetectorSubsystem.h>      // for PHG4DetectorSubsy...
+
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4SteppingAction.h>              // for PHG4SteppingAction
 
@@ -42,7 +44,7 @@ int PHG4Prototype2InnerHcalSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
   PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
 
   // create detector
-  m_Detector = new PHG4Prototype2InnerHcalDetector(topNode, GetParams(), Name());
+  m_Detector = new PHG4Prototype2InnerHcalDetector(this, topNode, GetParams(), Name());
   m_Detector->SuperDetector(SuperDetector());
   m_Detector->OverlapCheck(CheckOverlap());
   set<string> nodes;

--- a/simulation/g4simulation/g4caloprototype/PHG4Prototype2OuterHcalDetector.cc
+++ b/simulation/g4simulation/g4caloprototype/PHG4Prototype2OuterHcalDetector.cc
@@ -35,8 +35,8 @@ using namespace std;
 static const string scintimothername = "OuterHcalScintiMother";
 static const string steelplatename = "OuterHcalSteelPlate";
 
-PHG4Prototype2OuterHcalDetector::PHG4Prototype2OuterHcalDetector(PHCompositeNode* Node, PHParameters* parameters, const std::string& dnam)
-  : PHG4Detector(Node, dnam)
+PHG4Prototype2OuterHcalDetector::PHG4Prototype2OuterHcalDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, PHParameters* parameters, const std::string& dnam)
+  : PHG4Detector(subsys, Node, dnam)
   , m_Params(parameters)
   , m_OuterHcalSteelPlate(nullptr)
   , m_OuterHcalAssembly(nullptr)
@@ -390,7 +390,7 @@ PHG4Prototype2OuterHcalDetector::ConstructScintiTile12(G4LogicalVolume* hcalenve
 
 // Construct the envelope and the call the
 // actual outer hcal construction
-void PHG4Prototype2OuterHcalDetector::Construct(G4LogicalVolume* logicWorld)
+void PHG4Prototype2OuterHcalDetector::ConstructMe(G4LogicalVolume* logicWorld)
 {
   G4ThreeVector g4vec(m_Params->get_double_param("place_x") * cm,
                       m_Params->get_double_param("place_y") * cm,

--- a/simulation/g4simulation/g4caloprototype/PHG4Prototype2OuterHcalDetector.cc
+++ b/simulation/g4simulation/g4caloprototype/PHG4Prototype2OuterHcalDetector.cc
@@ -2,7 +2,7 @@
 
 #include <phparameter/PHParameters.h>
 
-#include <g4main/PHG4Detector.h>                   // for PHG4Detector
+#include <g4main/PHG4Detector.h>  // for PHG4Detector
 
 #include <Geant4/G4AssemblyVolume.hh>
 #include <Geant4/G4Box.hh>
@@ -11,22 +11,22 @@
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
 #include <Geant4/G4PVPlacement.hh>
-#include <Geant4/G4RotationMatrix.hh>              // for G4RotationMatrix
-#include <Geant4/G4String.hh>                      // for G4String
+#include <Geant4/G4RotationMatrix.hh>  // for G4RotationMatrix
+#include <Geant4/G4String.hh>          // for G4String
 #include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4ThreeVector.hh>                 // for G4ThreeVector
+#include <Geant4/G4ThreeVector.hh>  // for G4ThreeVector
 #include <Geant4/G4TwoVector.hh>
+#include <Geant4/G4VPhysicalVolume.hh>  // for G4VPhysicalVolume
+#include <Geant4/G4VSolid.hh>           // for G4VSolid
 #include <Geant4/G4VisAttributes.hh>
-#include <Geant4/G4VPhysicalVolume.hh>             // for G4VPhysicalVolume
-#include <Geant4/G4VSolid.hh>                      // for G4VSolid
 
 #include <boost/format.hpp>
 
 #include <cmath>
-#include <iostream>                                // for operator<<, endl
+#include <iostream>  // for operator<<, endl
 #include <sstream>
-#include <utility>                                 // for pair, make_pair
-#include <vector>                                  // for vector, vector<>::...
+#include <utility>  // for pair, make_pair
+#include <vector>   // for vector, vector<>::...
 
 class PHCompositeNode;
 

--- a/simulation/g4simulation/g4caloprototype/PHG4Prototype2OuterHcalDetector.h
+++ b/simulation/g4simulation/g4caloprototype/PHG4Prototype2OuterHcalDetector.h
@@ -9,7 +9,7 @@
 
 #include <map>
 #include <set>
-#include <string>                 // for string
+#include <string>  // for string
 
 class G4AssemblyVolume;
 class G4LogicalVolume;

--- a/simulation/g4simulation/g4caloprototype/PHG4Prototype2OuterHcalDetector.h
+++ b/simulation/g4simulation/g4caloprototype/PHG4Prototype2OuterHcalDetector.h
@@ -15,19 +15,20 @@ class G4AssemblyVolume;
 class G4LogicalVolume;
 class G4VPhysicalVolume;
 class PHCompositeNode;
+class PHG4Subsystem;
 class PHParameters;
 
 class PHG4Prototype2OuterHcalDetector : public PHG4Detector
 {
  public:
   //! constructor
-  PHG4Prototype2OuterHcalDetector(PHCompositeNode* Node, PHParameters* parameters, const std::string& dnam);
+  PHG4Prototype2OuterHcalDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, PHParameters* parameters, const std::string& dnam);
 
   //! destructor
   virtual ~PHG4Prototype2OuterHcalDetector();
 
   //! construct
-  virtual void Construct(G4LogicalVolume* world);
+  virtual void ConstructMe(G4LogicalVolume* world);
 
   virtual void Print(const std::string& what = "ALL") const;
 

--- a/simulation/g4simulation/g4caloprototype/PHG4Prototype2OuterHcalSubsystem.cc
+++ b/simulation/g4simulation/g4caloprototype/PHG4Prototype2OuterHcalSubsystem.cc
@@ -5,22 +5,22 @@
 
 #include <phparameter/PHParameters.h>
 
-#include <g4detectors/PHG4DetectorSubsystem.h>      // for PHG4DetectorSubsy...
+#include <g4detectors/PHG4DetectorSubsystem.h>  // for PHG4DetectorSubsy...
 
 #include <g4main/PHG4HitContainer.h>
-#include <g4main/PHG4SteppingAction.h>              // for PHG4SteppingAction
+#include <g4main/PHG4SteppingAction.h>  // for PHG4SteppingAction
 
 #include <phool/PHCompositeNode.h>
-#include <phool/PHIODataNode.h>                     // for PHIODataNode
-#include <phool/PHNode.h>                           // for PHNode
-#include <phool/PHNodeIterator.h>                   // for PHNodeIterator
-#include <phool/PHObject.h>                         // for PHObject
+#include <phool/PHIODataNode.h>    // for PHIODataNode
+#include <phool/PHNode.h>          // for PHNode
+#include <phool/PHNodeIterator.h>  // for PHNodeIterator
+#include <phool/PHObject.h>        // for PHObject
 #include <phool/getClass.h>
 
 #include <boost/foreach.hpp>
 
-#include <cmath>                                   // for NAN
-#include <iostream>                                 // for operator<<, basic...
+#include <cmath>     // for NAN
+#include <iostream>  // for operator<<, basic...
 #include <set>
 #include <sstream>
 

--- a/simulation/g4simulation/g4caloprototype/PHG4Prototype2OuterHcalSubsystem.cc
+++ b/simulation/g4simulation/g4caloprototype/PHG4Prototype2OuterHcalSubsystem.cc
@@ -5,6 +5,8 @@
 
 #include <phparameter/PHParameters.h>
 
+#include <g4detectors/PHG4DetectorSubsystem.h>      // for PHG4DetectorSubsy...
+
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4SteppingAction.h>              // for PHG4SteppingAction
 
@@ -42,7 +44,7 @@ int PHG4Prototype2OuterHcalSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
   PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
 
   // create detector
-  m_Detector = new PHG4Prototype2OuterHcalDetector(topNode, GetParams(), Name());
+  m_Detector = new PHG4Prototype2OuterHcalDetector(this, topNode, GetParams(), Name());
   m_Detector->SuperDetector(SuperDetector());
   m_Detector->OverlapCheck(CheckOverlap());
   set<string> nodes;

--- a/simulation/g4simulation/g4caloprototype/PHG4Prototype3InnerHcalDetector.cc
+++ b/simulation/g4simulation/g4caloprototype/PHG4Prototype3InnerHcalDetector.cc
@@ -2,7 +2,7 @@
 
 #include <phparameter/PHParameters.h>
 
-#include <g4main/PHG4Detector.h>                   // for PHG4Detector
+#include <g4main/PHG4Detector.h>  // for PHG4Detector
 #include <g4main/PHG4Units.h>
 
 #include <TSystem.h>
@@ -14,22 +14,22 @@
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
 #include <Geant4/G4PVPlacement.hh>
-#include <Geant4/G4RotationMatrix.hh>              // for G4RotationMatrix
-#include <Geant4/G4String.hh>                      // for G4String
-#include <Geant4/G4SystemOfUnits.hh>               // for mm, deg, cm, cm3, rad
-#include <Geant4/G4ThreeVector.hh>                 // for G4ThreeVector
+#include <Geant4/G4RotationMatrix.hh>  // for G4RotationMatrix
+#include <Geant4/G4String.hh>          // for G4String
+#include <Geant4/G4SystemOfUnits.hh>   // for mm, deg, cm, cm3, rad
+#include <Geant4/G4ThreeVector.hh>     // for G4ThreeVector
 #include <Geant4/G4TwoVector.hh>
+#include <Geant4/G4VPhysicalVolume.hh>  // for G4VPhysicalVolume
+#include <Geant4/G4VSolid.hh>           // for G4VSolid
 #include <Geant4/G4VisAttributes.hh>
-#include <Geant4/G4VPhysicalVolume.hh>             // for G4VPhysicalVolume
-#include <Geant4/G4VSolid.hh>                      // for G4VSolid
 
 #include <boost/format.hpp>
 
 #include <cmath>
-#include <iostream>                                // for operator<<, endl
+#include <iostream>  // for operator<<, endl
 #include <sstream>
-#include <utility>                                 // for pair, make_pair
-#include <vector>                                  // for vector, vector<>::...
+#include <utility>  // for pair, make_pair
+#include <vector>   // for vector, vector<>::...
 
 class PHCompositeNode;
 
@@ -38,7 +38,7 @@ using namespace std;
 static const string scintimothername = "InnerHcalScintiMother";
 static const string steelplatename = "InnerHcalSteelPlate";
 
-PHG4Prototype3InnerHcalDetector::PHG4Prototype3InnerHcalDetector(PHG4Subsystem* subsys, PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam)
+PHG4Prototype3InnerHcalDetector::PHG4Prototype3InnerHcalDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam)
   : PHG4Detector(subsys, Node, dnam)
   , m_params(parameters)
   , m_InnerHcalSteelPlate(nullptr)
@@ -94,7 +94,7 @@ PHG4Prototype3InnerHcalDetector::PHG4Prototype3InnerHcalDetector(PHG4Subsystem* 
   , m_AbsorberActive(m_params->get_int_param("absorberactive"))
   , m_Layer(0)
 {
-// patch to get the upper steel plate location right within less than a mm
+  // patch to get the upper steel plate location right within less than a mm
   m_DeltaPhi += 0.00125 * m_DeltaPhi;
 }
 
@@ -310,39 +310,39 @@ void PHG4Prototype3InnerHcalDetector::ConstructMe(G4LogicalVolume *logicWorld)
   m_InnerHcalAssembly = new G4AssemblyVolume();
   ConstructInnerHcal(logicWorld);
   m_InnerHcalAssembly->MakeImprint(logicWorld, g4vec, &Rot, 0, OverlapCheck());
-// this is rather pathetic - there is no way to extract the name when a volume is added
-// to the assembly. The only thing we can do is get an iterator over the placed volumes
-// in the order in which they were placed. Since this code does not install the scintillators
-// for the Al version, parsing the volume names to get the id does not work since it changes
-// So now we loop over all volumes and store them in a map for fast lookup of the row
+  // this is rather pathetic - there is no way to extract the name when a volume is added
+  // to the assembly. The only thing we can do is get an iterator over the placed volumes
+  // in the order in which they were placed. Since this code does not install the scintillators
+  // for the Al version, parsing the volume names to get the id does not work since it changes
+  // So now we loop over all volumes and store them in a map for fast lookup of the row
   int isteel = 0;
   int iscinti = 0;
-  vector<G4VPhysicalVolume*>::iterator it = m_InnerHcalAssembly->GetVolumesIterator();
-  for (unsigned int i=0; i<m_InnerHcalAssembly-> TotalImprintedVolumes();i++)
+  vector<G4VPhysicalVolume *>::iterator it = m_InnerHcalAssembly->GetVolumesIterator();
+  for (unsigned int i = 0; i < m_InnerHcalAssembly->TotalImprintedVolumes(); i++)
   {
     string volname = (*it)->GetName();
     if (volname.find(steelplatename) != string::npos)
-    { 
-      m_SteelPlateIdMap.insert(make_pair(volname,isteel));
+    {
+      m_SteelPlateIdMap.insert(make_pair(volname, isteel));
       ++isteel;
     }
     else if (volname.find(scintimothername) != string::npos)
     {
-      m_ScintillatorIdMap.insert(make_pair(volname,iscinti));
+      m_ScintillatorIdMap.insert(make_pair(volname, iscinti));
       ++iscinti;
     }
     ++it;
   }
-// print out volume names and their assigned id
-   // map<string,int>::const_iterator iter;
-   // for (iter = m_SteelPlateIdMap.begin(); iter != m_SteelPlateIdMap.end(); ++iter)
-   // {
-   //   cout << iter->first << ", " << iter->second << endl;
-   // }
-   // for (iter = m_ScintillatorIdMap.begin(); iter != m_ScintillatorIdMap.end(); ++iter)
-   // {
-   //   cout << iter->first << ", " << iter->second << endl;
-   // }
+  // print out volume names and their assigned id
+  // map<string,int>::const_iterator iter;
+  // for (iter = m_SteelPlateIdMap.begin(); iter != m_SteelPlateIdMap.end(); ++iter)
+  // {
+  //   cout << iter->first << ", " << iter->second << endl;
+  // }
+  // for (iter = m_ScintillatorIdMap.begin(); iter != m_ScintillatorIdMap.end(); ++iter)
+  // {
+  //   cout << iter->first << ", " << iter->second << endl;
+  // }
   return;
 }
 
@@ -425,7 +425,7 @@ void PHG4Prototype3InnerHcalDetector::Print(const string &what) const
 
 int PHG4Prototype3InnerHcalDetector::get_scinti_row_id(const string &volname)
 {
-  int id=-9999;
+  int id = -9999;
   auto it = m_ScintillatorIdMap.find(volname);
   if (it != m_ScintillatorIdMap.end())
   {
@@ -441,7 +441,7 @@ int PHG4Prototype3InnerHcalDetector::get_scinti_row_id(const string &volname)
 
 int PHG4Prototype3InnerHcalDetector::get_steel_plate_id(const string &volname)
 {
-  int id=-9999;
+  int id = -9999;
   auto it = m_SteelPlateIdMap.find(volname);
   if (it != m_SteelPlateIdMap.end())
   {

--- a/simulation/g4simulation/g4caloprototype/PHG4Prototype3InnerHcalDetector.cc
+++ b/simulation/g4simulation/g4caloprototype/PHG4Prototype3InnerHcalDetector.cc
@@ -38,8 +38,8 @@ using namespace std;
 static const string scintimothername = "InnerHcalScintiMother";
 static const string steelplatename = "InnerHcalSteelPlate";
 
-PHG4Prototype3InnerHcalDetector::PHG4Prototype3InnerHcalDetector(PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam)
-  : PHG4Detector(Node, dnam)
+PHG4Prototype3InnerHcalDetector::PHG4Prototype3InnerHcalDetector(PHG4Subsystem* subsys, PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam)
+  : PHG4Detector(subsys, Node, dnam)
   , m_params(parameters)
   , m_InnerHcalSteelPlate(nullptr)
   , m_InnerHcalAssembly(nullptr)
@@ -298,7 +298,7 @@ PHG4Prototype3InnerHcalDetector::ConstructScintiTile12(G4LogicalVolume *hcalenve
 
 // Construct the envelope and the call the
 // actual inner hcal construction
-void PHG4Prototype3InnerHcalDetector::Construct(G4LogicalVolume *logicWorld)
+void PHG4Prototype3InnerHcalDetector::ConstructMe(G4LogicalVolume *logicWorld)
 {
   G4ThreeVector g4vec(m_params->get_double_param("place_x") * cm,
                       m_params->get_double_param("place_y") * cm,

--- a/simulation/g4simulation/g4caloprototype/PHG4Prototype3InnerHcalDetector.h
+++ b/simulation/g4simulation/g4caloprototype/PHG4Prototype3InnerHcalDetector.h
@@ -22,7 +22,7 @@ class PHG4Prototype3InnerHcalDetector : public PHG4Detector
 {
  public:
   //! constructor
-  PHG4Prototype3InnerHcalDetector(PHG4Subsystem* subsys, PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam);
+  PHG4Prototype3InnerHcalDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam);
 
   //! destructor
   virtual ~PHG4Prototype3InnerHcalDetector();
@@ -113,8 +113,8 @@ class PHG4Prototype3InnerHcalDetector : public PHG4Detector
 
   int m_Layer;
   std::string m_SuperDetector;
-  std::map<std::string,int> m_SteelPlateIdMap;
-  std::map<std::string,int> m_ScintillatorIdMap;
+  std::map<std::string, int> m_SteelPlateIdMap;
+  std::map<std::string, int> m_ScintillatorIdMap;
 };
 
 #endif  // G4DETECTORS_PHG4PROTOTYPE3INNERHCALDETECTOR_H

--- a/simulation/g4simulation/g4caloprototype/PHG4Prototype3InnerHcalDetector.h
+++ b/simulation/g4simulation/g4caloprototype/PHG4Prototype3InnerHcalDetector.h
@@ -15,18 +15,19 @@ class G4AssemblyVolume;
 class G4LogicalVolume;
 class G4VPhysicalVolume;
 class PHCompositeNode;
+class PHG4Subsystem;
 class PHParameters;
 
 class PHG4Prototype3InnerHcalDetector : public PHG4Detector
 {
  public:
   //! constructor
-  PHG4Prototype3InnerHcalDetector(PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam);
+  PHG4Prototype3InnerHcalDetector(PHG4Subsystem* subsys, PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam);
 
   //! destructor
   virtual ~PHG4Prototype3InnerHcalDetector();
   //! construct method called by G4
-  void Construct(G4LogicalVolume *world);
+  void ConstructMe(G4LogicalVolume *world);
 
   //! print detector info
   void Print(const std::string &what = "ALL") const;

--- a/simulation/g4simulation/g4caloprototype/PHG4Prototype3InnerHcalSubsystem.cc
+++ b/simulation/g4simulation/g4caloprototype/PHG4Prototype3InnerHcalSubsystem.cc
@@ -5,6 +5,8 @@
 
 #include <phparameter/PHParameters.h>
 
+#include <phparameter/PHParameters.h>
+
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4SteppingAction.h>              // for PHG4SteppingAction
 
@@ -42,7 +44,7 @@ int PHG4Prototype3InnerHcalSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
   PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
 
   // create detector
-  m_Detector = new PHG4Prototype3InnerHcalDetector(topNode, GetParams(), Name());
+  m_Detector = new PHG4Prototype3InnerHcalDetector(this, topNode, GetParams(), Name());
   m_Detector->SuperDetector(SuperDetector());
   m_Detector->OverlapCheck(CheckOverlap());
   set<string> nodes;

--- a/simulation/g4simulation/g4caloprototype/PHG4Prototype3InnerHcalSubsystem.cc
+++ b/simulation/g4simulation/g4caloprototype/PHG4Prototype3InnerHcalSubsystem.cc
@@ -8,19 +8,19 @@
 #include <phparameter/PHParameters.h>
 
 #include <g4main/PHG4HitContainer.h>
-#include <g4main/PHG4SteppingAction.h>              // for PHG4SteppingAction
+#include <g4main/PHG4SteppingAction.h>  // for PHG4SteppingAction
 
 #include <phool/PHCompositeNode.h>
-#include <phool/PHIODataNode.h>                     // for PHIODataNode
-#include <phool/PHNode.h>                           // for PHNode
-#include <phool/PHNodeIterator.h>                   // for PHNodeIterator
-#include <phool/PHObject.h>                         // for PHObject
+#include <phool/PHIODataNode.h>    // for PHIODataNode
+#include <phool/PHNode.h>          // for PHNode
+#include <phool/PHNodeIterator.h>  // for PHNodeIterator
+#include <phool/PHObject.h>        // for PHObject
 #include <phool/getClass.h>
 
 #include <boost/foreach.hpp>
 
-#include <cmath>                                   // for NAN
-#include <iostream>                                 // for operator<<, basic...
+#include <cmath>     // for NAN
+#include <iostream>  // for operator<<, basic...
 #include <set>
 #include <sstream>
 
@@ -63,11 +63,11 @@ int PHG4Prototype3InnerHcalSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
     {
       if (SuperDetector() != "NONE")
       {
-	nodename << "G4HIT_" << SuperDetector();
+        nodename << "G4HIT_" << SuperDetector();
       }
       else
       {
-	nodename << "G4HIT_" << Name();
+        nodename << "G4HIT_" << Name();
       }
       nodes.insert(nodename.str());
     }

--- a/simulation/g4simulation/g4caloprototype/PHG4SpacalPrototype4Detector.cc
+++ b/simulation/g4simulation/g4caloprototype/PHG4SpacalPrototype4Detector.cc
@@ -6,7 +6,7 @@
 
 #include <phparameter/PHParameters.h>
 
-#include <g4main/PHG4Detector.h>                    // for PHG4Detector
+#include <g4main/PHG4Detector.h>  // for PHG4Detector
 #include <g4main/PHG4Utils.h>
 
 #include <phool/PHCompositeNode.h>
@@ -17,7 +17,7 @@
 #include <phool/getClass.h>
 
 #include <Geant4/G4Box.hh>
-#include <Geant4/G4Colour.hh>                       // for G4Colour
+#include <Geant4/G4Colour.hh>  // for G4Colour
 #include <Geant4/G4DisplacedSolid.hh>
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
@@ -40,14 +40,14 @@
 #include <algorithm>
 #include <cassert>
 #include <cmath>
-#include <cstdlib>                                 // for exit
+#include <cstdlib>   // for exit
 #include <iostream>  // for operator<<, basic_ostream
-#include <limits>                                   // for numeric_limits
-#include <memory>                                   // for allocator_traits<...
+#include <limits>    // for numeric_limits
+#include <memory>    // for allocator_traits<...
 #include <numeric>   // std::accumulate
 #include <sstream>
 #include <string>  // std::string, std::to_string
-#include <vector>                                   // for vector
+#include <vector>  // for vector
 
 class PHG4CylinderGeom;
 
@@ -405,8 +405,8 @@ PHG4SpacalPrototype4Detector::Construct_AzimuthalSeg()
   // enclosure walls
   const G4double edge1_tilt_angle = atan2(width_adj1, enclosure_depth * 0.5);
   const G4double edge2_tilt_angle = atan2(width_adj2, enclosure_depth * 0.5);
-//  const G4double edge1_half_depth = sqrt(width_adj1 * width_adj1 + enclosure_depth * enclosure_depth * .25);
-//  const G4double edge2_half_depth = sqrt(width_adj2 * width_adj2 + enclosure_depth * enclosure_depth * .25);
+  //  const G4double edge1_half_depth = sqrt(width_adj1 * width_adj1 + enclosure_depth * enclosure_depth * .25);
+  //  const G4double edge2_half_depth = sqrt(width_adj2 * width_adj2 + enclosure_depth * enclosure_depth * .25);
 
   // projective center
   const G4double half_projection_ratio = 0.5 * (-width_adj1 + width_adj2) / enclosure_half_height_half_width;
@@ -571,7 +571,6 @@ PHG4SpacalPrototype4Detector::Construct_AzimuthalSeg()
   G4LogicalVolume* sec_logic = new G4LogicalVolume(sec_solid_place, cylinder_mat,
                                                    G4String(G4String(GetName() + string("_sec"))), 0, 0, nullptr);
 
-
   G4VisAttributes* VisAtt = new G4VisAttributes();
   VisAtt->SetColor(.5, .9, .5, .1);
   VisAtt->SetVisibility(true);
@@ -579,183 +578,183 @@ PHG4SpacalPrototype4Detector::Construct_AzimuthalSeg()
   VisAtt->SetForceWireframe(true);
   sec_logic->SetVisAttributes(VisAtt);
 
-//  // construct walls
-//
-//  G4Material* wall_mat = G4Material::GetMaterial(_geom->get_sidewall_mat());
-//  assert(wall_mat);
-//
-//  if (_geom->get_sidewall_thickness() > 0)
-//  {
-//    // end walls
-//    if (_geom->get_construction_verbose() >= 1)
-//    {
-//      cout << "PHG4SpacalPrototype4Detector::Construct_AzimuthalSeg::" << GetName()
-//           << " - construct end walls." << endl;
-//    }
-//    //        G4Tubs* wall_solid = new G4Tubs(G4String(GetName() + string("_EndWall")),
-//    //            _geom->get_radius() * cm + _geom->get_sidewall_outer_torr() * cm,
-//    //            _geom->get_max_radius() * cm - _geom->get_sidewall_outer_torr() * cm,
-//    //            _geom->get_sidewall_thickness() * cm / 2.0,
-//    //            halfpi - pi / _geom->get_azimuthal_n_sec(),
-//    //            twopi / _geom->get_azimuthal_n_sec());
-//    const G4double side_wall_half_thickness = _geom->get_sidewall_thickness() * cm / 2.0;
-//    G4VSolid* wall_solid = new G4Trap(G4String(GetName() + string("_EndWall_trap")),
-//                                      enclosure_depth * 0.5,                                                  // G4double pDz,
-//                                      center_tilt_angle, halfpi,                                              // G4double pTheta, G4double pPhi,
-//                                      inner_half_width, side_wall_half_thickness, side_wall_half_thickness,   // G4double pDy1, G4double pDx1, G4double pDx2,
-//                                      0,                                                                      // G4double pAlp1,
-//                                      outter_half_width, side_wall_half_thickness, side_wall_half_thickness,  // G4double pDy2, G4double pDx3, G4double pDx4,
-//                                      0                                                                       // G4double pAlp2 //
-//    );
-//    G4VSolid* wall_solid_place = new G4DisplacedSolid(
-//        G4String(GetName() + string("_EndWall")), wall_solid, sec_solid_transform);
-//
-//    G4LogicalVolume* wall_logic = new G4LogicalVolume(wall_solid_place, wall_mat,
-//                                                      G4String(G4String(GetName() + string("_EndWall"))), 0, 0,
-//                                                      nullptr);
-//    GetDisplayAction()->AddVolume(wall_logic, "Wall");
-//
-//    typedef map<int, double> z_locations_t;
-//    z_locations_t z_locations;
-//    z_locations[000] = _geom->get_sidewall_thickness() * cm / 2.0 + _geom->get_assembly_spacing() * cm;
-//    z_locations[001] = _geom->get_length() * cm / 2.0 - (_geom->get_sidewall_thickness() * cm / 2.0 + _geom->get_assembly_spacing() * cm);
-//    z_locations[100] = -(_geom->get_sidewall_thickness() * cm / 2.0 + _geom->get_assembly_spacing() * cm);
-//    z_locations[101] = -(_geom->get_length() * cm / 2.0 - (_geom->get_sidewall_thickness() * cm / 2.0 + _geom->get_assembly_spacing() * cm));
-//
-//    BOOST_FOREACH (z_locations_t::value_type& val, z_locations)
-//    {
-//      if (_geom->get_construction_verbose() >= 2)
-//        cout << "PHG4SpacalPrototype4Detector::Construct_AzimuthalSeg::"
-//             << GetName() << " - constructed End Wall ID " << val.first
-//             << " @ Z = " << val.second << endl;
-//
-//      G4Transform3D wall_trans = G4TranslateZ3D(val.second);
-//
-//      G4PVPlacement* wall_phys = new G4PVPlacement(wall_trans, wall_logic,
-//                                                   G4String(GetName()) + G4String("_EndWall_") + to_string(val.first), sec_logic,
-//                                                   false, val.first, OverlapCheck());
-//
-//      calo_vol[wall_phys] = val.first;
-//      assert(gdml_config);
-//      gdml_config->exclude_physical_vol(wall_phys);
-//    }
-//  }
-//  //
-//  if (_geom->get_sidewall_thickness() > 0)
-//  {
-//    // side walls
-//    if (_geom->get_construction_verbose() >= 1)
-//    {
-//      cout << "PHG4SpacalPrototype4Detector::Construct_AzimuthalSeg::" << GetName()
-//           << " - construct side walls." << endl;
-//    }
-//
-//    typedef map<int, pair<int, int> > sign_t;
-//    sign_t signs;
-//    signs[100] = make_pair(+1, +1);
-//    signs[101] = make_pair(+1, -1);
-//    signs[200] = make_pair(-1, +1);
-//    signs[201] = make_pair(-1, -1);
-//
-//    BOOST_FOREACH (sign_t::value_type& val, signs)
-//    {
-//      const int sign_z = val.second.first;
-//      const int sign_azimuth = val.second.second;
-//
-//      if (_geom->get_construction_verbose() >= 2)
-//        cout << "PHG4SpacalPrototype4Detector::Construct_AzimuthalSeg::"
-//             << GetName() << " - constructed Side Wall ID " << val.first
-//             << " with"
-//             << " Shift X = "
-//             << sign_azimuth * (_geom->get_sidewall_thickness() * cm / 2.0 + _geom->get_sidewall_outer_torr() * cm)
-//             << " Rotation Z = "
-//             << sign_azimuth * pi / _geom->get_azimuthal_n_sec()
-//             << " Shift Z = " << sign_z * (_geom->get_length() * cm / 4)
-//             << endl;
-//
-//      const G4double azimuth_roate =
-//          sign_azimuth > 0 ? edge1_tilt_angle : edge2_tilt_angle;
-//      const G4double edge_half_depth = -_geom->get_sidewall_thickness() * cm - _geom->get_sidewall_outer_torr() * cm +
-//                                       (sign_azimuth > 0 ? edge1_half_depth : edge2_half_depth);
-//
-//      G4Box* wall_solid = new G4Box(G4String(GetName() + G4String("_SideWall_") + to_string(val.first)),
-//                                    _geom->get_sidewall_thickness() * cm / 2.0,
-//                                    edge_half_depth,
-//                                    (_geom->get_length() / 2. - 2 * (_geom->get_sidewall_thickness() + 2. * _geom->get_assembly_spacing())) * cm * .5);
-//
-//      G4LogicalVolume* wall_logic = new G4LogicalVolume(wall_solid, wall_mat,
-//                                                        G4String(G4String(GetName() + G4String("_SideWall_") + to_string(val.first))), 0, 0,
-//                                                        nullptr);
-//      GetDisplayAction()->AddVolume(wall_logic, "Wall");
-//
-//      const G4Transform3D wall_trans =
-//          G4TranslateZ3D(sign_z * (_geom->get_length() * cm / 4)) *
-//          G4TranslateY3D(enclosure_center) *
-//          G4TranslateX3D(sign_azimuth * enclosure_half_height_half_width) *
-//          G4RotateZ3D(azimuth_roate) *
-//          G4TranslateX3D(-sign_azimuth * (_geom->get_sidewall_thickness() * cm / 2.0 + _geom->get_sidewall_outer_torr() * cm));
-//
-//      G4PVPlacement* wall_phys = new G4PVPlacement(wall_trans, wall_logic,
-//                                                   G4String(GetName()) + G4String("_SideWall_") + to_string(val.first), sec_logic,
-//                                                   false, val.first, OverlapCheck());
-//
-//      calo_vol[wall_phys] = val.first;
-//      assert(gdml_config);
-//      gdml_config->exclude_physical_vol(wall_phys);
-//    }
-//  }
-//
-//  // construct dividers
-//  if (_geom->get_divider_width() > 0)
-//  {
-//    if (_geom->get_construction_verbose() >= 1)
-//    {
-//      cout << "PHG4SpacalPrototype4Detector::Construct_AzimuthalSeg::" << GetName()
-//           << " - construct dividers" << endl;
-//    }
-//
-//    G4Material* divider_mat = G4Material::GetMaterial(_geom->get_divider_mat());
-//    assert(divider_mat);
-//
-//    int ID = 300;
-//    for (const auto& geom : divider_azimuth_geoms)
-//    {
-//      G4Box* divider_solid = new G4Box(G4String(GetName() + G4String("_Divider_") + to_string(ID)),
-//                                       geom.thickness / 2.0,
-//                                       geom.width / 2.,
-//                                       (_geom->get_length() / 2. - 2 * (_geom->get_sidewall_thickness() + 2. * _geom->get_assembly_spacing())) * cm * .5);
-//
-//      G4LogicalVolume* wall_logic = new G4LogicalVolume(divider_solid, divider_mat,
-//                                                        G4String(G4String(GetName() + G4String("_Divider_") + to_string(ID))), 0, 0,
-//                                                        nullptr);
-//      GetDisplayAction()->AddVolume(wall_logic, "Divider");
-//
-//      for (int sign_z = -1; sign_z <= 1; sign_z += 2)
-//      {
-//        G4Transform3D wall_trans =
-//            G4TranslateX3D(geom.projection_center_x) *
-//            G4TranslateY3D(geom.projection_center_y) *
-//            G4RotateZ3D(geom.angle) *
-//            G4TranslateY3D(geom.radial_displacement) *
-//            G4TranslateZ3D(sign_z * (_geom->get_length() * cm / 4));
-//
-//        G4PVPlacement* wall_phys = new G4PVPlacement(wall_trans, wall_logic,
-//                                                     G4String(GetName()) + G4String("_Divider_") + to_string(ID), sec_logic,
-//                                                     false, ID, OverlapCheck());
-//
-//        calo_vol[wall_phys] = ID;
-//        //        assert(gdml_config);
-//        //        gdml_config->exclude_physical_vol(wall_phys);
-//
-//        if (Verbosity())
-//        {
-//          cout << "PHG4SpacalPrototype4Detector::Construct_AzimuthalSeg - placing divider " << wall_phys->GetName() << " copy ID " << ID << endl;
-//        }
-//
-//        ++ID;
-//      }
-//    }  //    for (const auto & geom : divider_azimuth_geoms)
-//  }
+  //  // construct walls
+  //
+  //  G4Material* wall_mat = G4Material::GetMaterial(_geom->get_sidewall_mat());
+  //  assert(wall_mat);
+  //
+  //  if (_geom->get_sidewall_thickness() > 0)
+  //  {
+  //    // end walls
+  //    if (_geom->get_construction_verbose() >= 1)
+  //    {
+  //      cout << "PHG4SpacalPrototype4Detector::Construct_AzimuthalSeg::" << GetName()
+  //           << " - construct end walls." << endl;
+  //    }
+  //    //        G4Tubs* wall_solid = new G4Tubs(G4String(GetName() + string("_EndWall")),
+  //    //            _geom->get_radius() * cm + _geom->get_sidewall_outer_torr() * cm,
+  //    //            _geom->get_max_radius() * cm - _geom->get_sidewall_outer_torr() * cm,
+  //    //            _geom->get_sidewall_thickness() * cm / 2.0,
+  //    //            halfpi - pi / _geom->get_azimuthal_n_sec(),
+  //    //            twopi / _geom->get_azimuthal_n_sec());
+  //    const G4double side_wall_half_thickness = _geom->get_sidewall_thickness() * cm / 2.0;
+  //    G4VSolid* wall_solid = new G4Trap(G4String(GetName() + string("_EndWall_trap")),
+  //                                      enclosure_depth * 0.5,                                                  // G4double pDz,
+  //                                      center_tilt_angle, halfpi,                                              // G4double pTheta, G4double pPhi,
+  //                                      inner_half_width, side_wall_half_thickness, side_wall_half_thickness,   // G4double pDy1, G4double pDx1, G4double pDx2,
+  //                                      0,                                                                      // G4double pAlp1,
+  //                                      outter_half_width, side_wall_half_thickness, side_wall_half_thickness,  // G4double pDy2, G4double pDx3, G4double pDx4,
+  //                                      0                                                                       // G4double pAlp2 //
+  //    );
+  //    G4VSolid* wall_solid_place = new G4DisplacedSolid(
+  //        G4String(GetName() + string("_EndWall")), wall_solid, sec_solid_transform);
+  //
+  //    G4LogicalVolume* wall_logic = new G4LogicalVolume(wall_solid_place, wall_mat,
+  //                                                      G4String(G4String(GetName() + string("_EndWall"))), 0, 0,
+  //                                                      nullptr);
+  //    GetDisplayAction()->AddVolume(wall_logic, "Wall");
+  //
+  //    typedef map<int, double> z_locations_t;
+  //    z_locations_t z_locations;
+  //    z_locations[000] = _geom->get_sidewall_thickness() * cm / 2.0 + _geom->get_assembly_spacing() * cm;
+  //    z_locations[001] = _geom->get_length() * cm / 2.0 - (_geom->get_sidewall_thickness() * cm / 2.0 + _geom->get_assembly_spacing() * cm);
+  //    z_locations[100] = -(_geom->get_sidewall_thickness() * cm / 2.0 + _geom->get_assembly_spacing() * cm);
+  //    z_locations[101] = -(_geom->get_length() * cm / 2.0 - (_geom->get_sidewall_thickness() * cm / 2.0 + _geom->get_assembly_spacing() * cm));
+  //
+  //    BOOST_FOREACH (z_locations_t::value_type& val, z_locations)
+  //    {
+  //      if (_geom->get_construction_verbose() >= 2)
+  //        cout << "PHG4SpacalPrototype4Detector::Construct_AzimuthalSeg::"
+  //             << GetName() << " - constructed End Wall ID " << val.first
+  //             << " @ Z = " << val.second << endl;
+  //
+  //      G4Transform3D wall_trans = G4TranslateZ3D(val.second);
+  //
+  //      G4PVPlacement* wall_phys = new G4PVPlacement(wall_trans, wall_logic,
+  //                                                   G4String(GetName()) + G4String("_EndWall_") + to_string(val.first), sec_logic,
+  //                                                   false, val.first, OverlapCheck());
+  //
+  //      calo_vol[wall_phys] = val.first;
+  //      assert(gdml_config);
+  //      gdml_config->exclude_physical_vol(wall_phys);
+  //    }
+  //  }
+  //  //
+  //  if (_geom->get_sidewall_thickness() > 0)
+  //  {
+  //    // side walls
+  //    if (_geom->get_construction_verbose() >= 1)
+  //    {
+  //      cout << "PHG4SpacalPrototype4Detector::Construct_AzimuthalSeg::" << GetName()
+  //           << " - construct side walls." << endl;
+  //    }
+  //
+  //    typedef map<int, pair<int, int> > sign_t;
+  //    sign_t signs;
+  //    signs[100] = make_pair(+1, +1);
+  //    signs[101] = make_pair(+1, -1);
+  //    signs[200] = make_pair(-1, +1);
+  //    signs[201] = make_pair(-1, -1);
+  //
+  //    BOOST_FOREACH (sign_t::value_type& val, signs)
+  //    {
+  //      const int sign_z = val.second.first;
+  //      const int sign_azimuth = val.second.second;
+  //
+  //      if (_geom->get_construction_verbose() >= 2)
+  //        cout << "PHG4SpacalPrototype4Detector::Construct_AzimuthalSeg::"
+  //             << GetName() << " - constructed Side Wall ID " << val.first
+  //             << " with"
+  //             << " Shift X = "
+  //             << sign_azimuth * (_geom->get_sidewall_thickness() * cm / 2.0 + _geom->get_sidewall_outer_torr() * cm)
+  //             << " Rotation Z = "
+  //             << sign_azimuth * pi / _geom->get_azimuthal_n_sec()
+  //             << " Shift Z = " << sign_z * (_geom->get_length() * cm / 4)
+  //             << endl;
+  //
+  //      const G4double azimuth_roate =
+  //          sign_azimuth > 0 ? edge1_tilt_angle : edge2_tilt_angle;
+  //      const G4double edge_half_depth = -_geom->get_sidewall_thickness() * cm - _geom->get_sidewall_outer_torr() * cm +
+  //                                       (sign_azimuth > 0 ? edge1_half_depth : edge2_half_depth);
+  //
+  //      G4Box* wall_solid = new G4Box(G4String(GetName() + G4String("_SideWall_") + to_string(val.first)),
+  //                                    _geom->get_sidewall_thickness() * cm / 2.0,
+  //                                    edge_half_depth,
+  //                                    (_geom->get_length() / 2. - 2 * (_geom->get_sidewall_thickness() + 2. * _geom->get_assembly_spacing())) * cm * .5);
+  //
+  //      G4LogicalVolume* wall_logic = new G4LogicalVolume(wall_solid, wall_mat,
+  //                                                        G4String(G4String(GetName() + G4String("_SideWall_") + to_string(val.first))), 0, 0,
+  //                                                        nullptr);
+  //      GetDisplayAction()->AddVolume(wall_logic, "Wall");
+  //
+  //      const G4Transform3D wall_trans =
+  //          G4TranslateZ3D(sign_z * (_geom->get_length() * cm / 4)) *
+  //          G4TranslateY3D(enclosure_center) *
+  //          G4TranslateX3D(sign_azimuth * enclosure_half_height_half_width) *
+  //          G4RotateZ3D(azimuth_roate) *
+  //          G4TranslateX3D(-sign_azimuth * (_geom->get_sidewall_thickness() * cm / 2.0 + _geom->get_sidewall_outer_torr() * cm));
+  //
+  //      G4PVPlacement* wall_phys = new G4PVPlacement(wall_trans, wall_logic,
+  //                                                   G4String(GetName()) + G4String("_SideWall_") + to_string(val.first), sec_logic,
+  //                                                   false, val.first, OverlapCheck());
+  //
+  //      calo_vol[wall_phys] = val.first;
+  //      assert(gdml_config);
+  //      gdml_config->exclude_physical_vol(wall_phys);
+  //    }
+  //  }
+  //
+  //  // construct dividers
+  //  if (_geom->get_divider_width() > 0)
+  //  {
+  //    if (_geom->get_construction_verbose() >= 1)
+  //    {
+  //      cout << "PHG4SpacalPrototype4Detector::Construct_AzimuthalSeg::" << GetName()
+  //           << " - construct dividers" << endl;
+  //    }
+  //
+  //    G4Material* divider_mat = G4Material::GetMaterial(_geom->get_divider_mat());
+  //    assert(divider_mat);
+  //
+  //    int ID = 300;
+  //    for (const auto& geom : divider_azimuth_geoms)
+  //    {
+  //      G4Box* divider_solid = new G4Box(G4String(GetName() + G4String("_Divider_") + to_string(ID)),
+  //                                       geom.thickness / 2.0,
+  //                                       geom.width / 2.,
+  //                                       (_geom->get_length() / 2. - 2 * (_geom->get_sidewall_thickness() + 2. * _geom->get_assembly_spacing())) * cm * .5);
+  //
+  //      G4LogicalVolume* wall_logic = new G4LogicalVolume(divider_solid, divider_mat,
+  //                                                        G4String(G4String(GetName() + G4String("_Divider_") + to_string(ID))), 0, 0,
+  //                                                        nullptr);
+  //      GetDisplayAction()->AddVolume(wall_logic, "Divider");
+  //
+  //      for (int sign_z = -1; sign_z <= 1; sign_z += 2)
+  //      {
+  //        G4Transform3D wall_trans =
+  //            G4TranslateX3D(geom.projection_center_x) *
+  //            G4TranslateY3D(geom.projection_center_y) *
+  //            G4RotateZ3D(geom.angle) *
+  //            G4TranslateY3D(geom.radial_displacement) *
+  //            G4TranslateZ3D(sign_z * (_geom->get_length() * cm / 4));
+  //
+  //        G4PVPlacement* wall_phys = new G4PVPlacement(wall_trans, wall_logic,
+  //                                                     G4String(GetName()) + G4String("_Divider_") + to_string(ID), sec_logic,
+  //                                                     false, ID, OverlapCheck());
+  //
+  //        calo_vol[wall_phys] = ID;
+  //        //        assert(gdml_config);
+  //        //        gdml_config->exclude_physical_vol(wall_phys);
+  //
+  //        if (Verbosity())
+  //        {
+  //          cout << "PHG4SpacalPrototype4Detector::Construct_AzimuthalSeg - placing divider " << wall_phys->GetName() << " copy ID " << ID << endl;
+  //        }
+  //
+  //        ++ID;
+  //      }
+  //    }  //    for (const auto & geom : divider_azimuth_geoms)
+  //  }
 
   //  // construct towers
   //

--- a/simulation/g4simulation/g4caloprototype/PHG4SpacalPrototype4Detector.cc
+++ b/simulation/g4simulation/g4caloprototype/PHG4SpacalPrototype4Detector.cc
@@ -2,9 +2,11 @@
 
 #include <g4detectors/PHG4CylinderGeomContainer.h>
 #include <g4detectors/PHG4CylinderGeom_Spacalv1.h>  // for PHG4CylinderGeom_Spacalv1:...
+#include <g4detectors/PHG4CylinderGeom_Spacalv3.h>  // for PHG4CylinderGeom_...
 
 #include <phparameter/PHParameters.h>
 
+#include <g4main/PHG4Detector.h>                    // for PHG4Detector
 #include <g4main/PHG4Utils.h>
 
 #include <phool/PHCompositeNode.h>
@@ -15,6 +17,7 @@
 #include <phool/getClass.h>
 
 #include <Geant4/G4Box.hh>
+#include <Geant4/G4Colour.hh>                       // for G4Colour
 #include <Geant4/G4DisplacedSolid.hh>
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
@@ -37,10 +40,14 @@
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <cstdlib>                                 // for exit
 #include <iostream>  // for operator<<, basic_ostream
+#include <limits>                                   // for numeric_limits
+#include <memory>                                   // for allocator_traits<...
 #include <numeric>   // std::accumulate
 #include <sstream>
 #include <string>  // std::string, std::to_string
+#include <vector>                                   // for vector
 
 class PHG4CylinderGeom;
 
@@ -48,8 +55,8 @@ using namespace std;
 
 //_______________________________________________________________
 //note this inactive thickness is ~1.5% of a radiation length
-PHG4SpacalPrototype4Detector::PHG4SpacalPrototype4Detector(PHCompositeNode* Node, PHParameters* parameters, const std::string& dnam)
-  : PHG4Detector(Node, dnam)
+PHG4SpacalPrototype4Detector::PHG4SpacalPrototype4Detector(PHG4Subsystem* subsys, PHCompositeNode* Node, PHParameters* parameters, const std::string& dnam)
+  : PHG4Detector(subsys, Node, dnam)
   , construction_params(parameters)
   , cylinder_solid(nullptr)
   , cylinder_logic(nullptr)
@@ -104,7 +111,7 @@ int PHG4SpacalPrototype4Detector::IsInCylinderActive(
 }
 
 //_______________________________________________________________
-void PHG4SpacalPrototype4Detector::Construct(G4LogicalVolume* logicWorld)
+void PHG4SpacalPrototype4Detector::ConstructMe(G4LogicalVolume* logicWorld)
 {
   PHNodeIterator iter(topNode());
   PHCompositeNode* parNode = dynamic_cast<PHCompositeNode*>(iter.findFirst(

--- a/simulation/g4simulation/g4caloprototype/PHG4SpacalPrototype4Detector.h
+++ b/simulation/g4simulation/g4caloprototype/PHG4SpacalPrototype4Detector.h
@@ -20,6 +20,7 @@ class G4UserLimits;
 class G4VPhysicalVolume;
 class G4VSolid;
 class PHCompositeNode;
+class PHG4Subsystem;
 class PHParameters;
 
 class PHG4SpacalPrototype4Detector : public PHG4Detector
@@ -27,12 +28,12 @@ class PHG4SpacalPrototype4Detector : public PHG4Detector
  public:
   typedef PHG4CylinderGeom_Spacalv3 SpacalGeom_t;
 
-  PHG4SpacalPrototype4Detector(PHCompositeNode* Node, PHParameters* parameters, const std::string& dnam);
+  PHG4SpacalPrototype4Detector(PHG4Subsystem* subsys, PHCompositeNode* Node, PHParameters* parameters, const std::string& dnam);
 
   virtual ~PHG4SpacalPrototype4Detector(void);
 
   virtual void
-  Construct(G4LogicalVolume* world);
+  ConstructMe(G4LogicalVolume* world);
 
   virtual std::pair<G4LogicalVolume*, G4Transform3D>
   Construct_AzimuthalSeg();

--- a/simulation/g4simulation/g4caloprototype/PHG4SpacalPrototype4Subsystem.cc
+++ b/simulation/g4simulation/g4caloprototype/PHG4SpacalPrototype4Subsystem.cc
@@ -41,7 +41,7 @@ int PHG4SpacalPrototype4Subsystem::InitRunSubsystem(PHCompositeNode* topNode)
     cout
         << "PHG4SpacalPrototype4Subsystem::InitRun - use PHG4SpacalPrototype4Detector"
         << endl;
-  detector_ = new PHG4SpacalPrototype4Detector(topNode, GetParams(), Name());
+  detector_ = new PHG4SpacalPrototype4Detector(this, topNode, GetParams(), Name());
 
   detector_->SetActive(GetParams()->get_int_param("active"));
   detector_->SetAbsorberActive(GetParams()->get_int_param("absorberactive"));

--- a/simulation/g4simulation/g4caloprototype/PHG4SpacalPrototypeDetector.cc
+++ b/simulation/g4simulation/g4caloprototype/PHG4SpacalPrototypeDetector.cc
@@ -5,6 +5,8 @@
 
 #include <phparameter/PHParameters.h>
 
+#include <g4detectors/PHG4CylinderGeom_Spacalv3.h>  // for PHG4CylinderGeom_...
+#include <g4main/PHG4Detector.h>                    // for PHG4Detector
 #include <g4main/PHG4Utils.h>
 
 #include <phool/PHCompositeNode.h>
@@ -41,6 +43,7 @@
 #include <numeric>   // std::accumulate
 #include <sstream>
 #include <string>  // std::string, std::to_string
+#include <vector>                                   // for vector
 
 class PHG4CylinderGeom;
 
@@ -48,8 +51,8 @@ using namespace std;
 
 //_______________________________________________________________
 //note this inactive thickness is ~1.5% of a radiation length
-PHG4SpacalPrototypeDetector::PHG4SpacalPrototypeDetector(PHCompositeNode* Node, PHParameters* parameters, const std::string& dnam)
-  : PHG4Detector(Node, dnam)
+PHG4SpacalPrototypeDetector::PHG4SpacalPrototypeDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, PHParameters* parameters, const std::string& dnam)
+  : PHG4Detector(subsys, Node, dnam)
   , construction_params(parameters)
   , cylinder_solid(nullptr)
   , cylinder_logic(nullptr)
@@ -101,7 +104,7 @@ int PHG4SpacalPrototypeDetector::IsInCylinderActive(
 }
 
 //_______________________________________________________________
-void PHG4SpacalPrototypeDetector::Construct(G4LogicalVolume* logicWorld)
+void PHG4SpacalPrototypeDetector::ConstructMe(G4LogicalVolume* logicWorld)
 {
   PHNodeIterator iter(topNode());
   PHCompositeNode* parNode = dynamic_cast<PHCompositeNode*>(iter.findFirst(

--- a/simulation/g4simulation/g4caloprototype/PHG4SpacalPrototypeDetector.cc
+++ b/simulation/g4simulation/g4caloprototype/PHG4SpacalPrototypeDetector.cc
@@ -43,7 +43,7 @@
 #include <numeric>   // std::accumulate
 #include <sstream>
 #include <string>  // std::string, std::to_string
-#include <vector>                                   // for vector
+#include <vector>  // for vector
 
 class PHG4CylinderGeom;
 

--- a/simulation/g4simulation/g4caloprototype/PHG4SpacalPrototypeDetector.h
+++ b/simulation/g4simulation/g4caloprototype/PHG4SpacalPrototypeDetector.h
@@ -8,11 +8,11 @@
 
 #include <g4main/PHG4Detector.h>
 
-#include <Geant4/G4Types.hh>
 #include <Geant4/G4Transform3D.hh>
+#include <Geant4/G4Types.hh>
 
 #include <map>
-#include <string>                       // for string
+#include <string>  // for string
 #include <utility>
 
 class G4LogicalVolume;
@@ -25,36 +25,33 @@ class PHParameters;
 
 class PHG4SpacalPrototypeDetector : public PHG4Detector
 {
-
-public:
+ public:
   typedef PHG4CylinderGeom_Spacalv3 SpacalGeom_t;
 
-  PHG4SpacalPrototypeDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, PHParameters *parameters, const std::string& dnam);
+  PHG4SpacalPrototypeDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, PHParameters* parameters, const std::string& dnam);
 
-  virtual
-  ~PHG4SpacalPrototypeDetector(void);
+  virtual ~PHG4SpacalPrototypeDetector(void);
 
   virtual void
   ConstructMe(G4LogicalVolume* world);
 
-  virtual std::pair<G4LogicalVolume *, G4Transform3D>
+  virtual std::pair<G4LogicalVolume*, G4Transform3D>
   Construct_AzimuthalSeg();
 
   //! a block along z axis built with G4Trd that is slightly tapered in x dimension
   virtual G4LogicalVolume*
-  Construct_Tower(const SpacalGeom_t::geom_tower & tower);
+  Construct_Tower(const SpacalGeom_t::geom_tower& tower);
   //! a block for the light guide along z axis that fit to the tower
   virtual G4LogicalVolume*
-  Construct_LightGuide(const SpacalGeom_t::geom_tower & tower, const int index_x, const int index_y);
+  Construct_LightGuide(const SpacalGeom_t::geom_tower& tower, const int index_x, const int index_y);
 
   //! Fully projective spacal with 2D tapered modules. To speed up construction, same-length fiber is used cross one tower
   virtual int
   Construct_Fibers_SameLengthFiberPerTower(
-      const SpacalGeom_t::geom_tower & tower, G4LogicalVolume* LV_tower);
+      const SpacalGeom_t::geom_tower& tower, G4LogicalVolume* LV_tower);
 
-  virtual
-  G4LogicalVolume *
-  Construct_Fiber(const G4double length, const std::string & id);
+  virtual G4LogicalVolume*
+  Construct_Fiber(const G4double length, const std::string& id);
 
   void
   SetActive(const int i = 1)
@@ -74,8 +71,7 @@ public:
     detector_type = typ;
   }
 
-  int
-  IsInCylinderActive(const G4VPhysicalVolume*);
+  int IsInCylinderActive(const G4VPhysicalVolume*);
 
   void
   SuperDetector(const std::string& name)
@@ -92,7 +88,7 @@ public:
   virtual void
   Print(const std::string& what = "ALL") const;
 
-  const SpacalGeom_t *
+  const SpacalGeom_t*
   get_geom() const
   {
     return _geom;
@@ -107,9 +103,8 @@ public:
     INACTIVE = -100
   };
 
-protected:
-
-  PHParameters *construction_params;
+ protected:
+  PHParameters* construction_params;
 
   G4VSolid* cylinder_solid;
   G4LogicalVolume* cylinder_logic;
@@ -130,13 +125,12 @@ protected:
   std::string detector_type;
   std::string superdetector;
 
-  G4UserLimits * step_limits;
-  G4UserLimits * clading_step_limits;
-  G4UserLimits * fiber_core_step_limits;
+  G4UserLimits* step_limits;
+  G4UserLimits* clading_step_limits;
+  G4UserLimits* fiber_core_step_limits;
 
-private:
-  SpacalGeom_t * _geom;
-
+ private:
+  SpacalGeom_t* _geom;
 };
 
 #endif

--- a/simulation/g4simulation/g4caloprototype/PHG4SpacalPrototypeDetector.h
+++ b/simulation/g4simulation/g4caloprototype/PHG4SpacalPrototypeDetector.h
@@ -20,6 +20,7 @@ class G4UserLimits;
 class G4VPhysicalVolume;
 class G4VSolid;
 class PHCompositeNode;
+class PHG4Subsystem;
 class PHParameters;
 
 class PHG4SpacalPrototypeDetector : public PHG4Detector
@@ -28,14 +29,13 @@ class PHG4SpacalPrototypeDetector : public PHG4Detector
 public:
   typedef PHG4CylinderGeom_Spacalv3 SpacalGeom_t;
 
-  PHG4SpacalPrototypeDetector(PHCompositeNode* Node, PHParameters *parameters, const std::string& dnam);
+  PHG4SpacalPrototypeDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, PHParameters *parameters, const std::string& dnam);
 
   virtual
   ~PHG4SpacalPrototypeDetector(void);
 
-  virtual
-  void
-  Construct(G4LogicalVolume* world);
+  virtual void
+  ConstructMe(G4LogicalVolume* world);
 
   virtual std::pair<G4LogicalVolume *, G4Transform3D>
   Construct_AzimuthalSeg();

--- a/simulation/g4simulation/g4caloprototype/PHG4SpacalPrototypeSubsystem.cc
+++ b/simulation/g4simulation/g4caloprototype/PHG4SpacalPrototypeSubsystem.cc
@@ -1,6 +1,5 @@
 #include "PHG4SpacalPrototypeSubsystem.h"
 
-
 #include "PHG4SpacalPrototypeDetector.h"
 #include "PHG4SpacalPrototypeSteppingAction.h"
 
@@ -9,16 +8,16 @@
 #include <g4detectors/PHG4DetectorSubsystem.h>  // for PHG4DetectorSubsystem
 
 #include <g4main/PHG4HitContainer.h>
-#include <g4main/PHG4SteppingAction.h>          // for PHG4SteppingAction
+#include <g4main/PHG4SteppingAction.h>  // for PHG4SteppingAction
 
 #include <phool/PHCompositeNode.h>
-#include <phool/PHIODataNode.h>                 // for PHIODataNode
-#include <phool/PHNode.h>                       // for PHNode
-#include <phool/PHNodeIterator.h>               // for PHNodeIterator
-#include <phool/PHObject.h>                     // for PHObject
+#include <phool/PHIODataNode.h>    // for PHIODataNode
+#include <phool/PHNode.h>          // for PHNode
+#include <phool/PHNodeIterator.h>  // for PHNodeIterator
+#include <phool/PHObject.h>        // for PHObject
 #include <phool/getClass.h>
 
-#include <iostream>                             // for operator<<, basic_ost...
+#include <iostream>  // for operator<<, basic_ost...
 #include <sstream>
 
 class PHG4Detector;
@@ -26,20 +25,19 @@ class PHG4Detector;
 using namespace std;
 
 //_______________________________________________________________________
-PHG4SpacalPrototypeSubsystem::PHG4SpacalPrototypeSubsystem(const std::string &na) :
-    PHG4DetectorSubsystem(na,0),
-    detector_(nullptr), 
-    steppingAction_(nullptr)
+PHG4SpacalPrototypeSubsystem::PHG4SpacalPrototypeSubsystem(const std::string& na)
+  : PHG4DetectorSubsystem(na, 0)
+  , detector_(nullptr)
+  , steppingAction_(nullptr)
 {
   InitializeParameters();
 }
 
 //_______________________________________________________________________
-int
-PHG4SpacalPrototypeSubsystem::InitRunSubsystem(PHCompositeNode* topNode)
+int PHG4SpacalPrototypeSubsystem::InitRunSubsystem(PHCompositeNode* topNode)
 {
-  PHNodeIterator iter( topNode );
-  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST" ));
+  PHNodeIterator iter(topNode);
+  PHCompositeNode* dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
 
   if (Verbosity() > 0)
     cout
@@ -53,65 +51,62 @@ PHG4SpacalPrototypeSubsystem::InitRunSubsystem(PHCompositeNode* topNode)
   detector_->OverlapCheck(CheckOverlap());
 
   if (GetParams()->get_int_param("active"))
+  {
+    ostringstream nodename;
+    if (SuperDetector() != "NONE")
     {
-      ostringstream nodename;
-      if (SuperDetector() != "NONE")
-        {
-          nodename << "G4HIT_" << SuperDetector();
-        }
-      else
-        {
-          nodename << "G4HIT_" << Name();
-        }
-      PHG4HitContainer* cylinder_hits = findNode::getClass<PHG4HitContainer>(
-          topNode, nodename.str());
-      if (!cylinder_hits)
-        {
-          dstNode->addNode(
-              new PHIODataNode<PHObject>(
-                  cylinder_hits = new PHG4HitContainer(nodename.str()),
-                  nodename.str(), "PHObject"));
-        }
-      cylinder_hits->AddLayer(0);
-      if (GetParams()->get_int_param("absorberactive"))
-        {
-          nodename.str("");
-          if (SuperDetector() != "NONE")
-            {
-              nodename << "G4HIT_ABSORBER_" << SuperDetector();
-            }
-          else
-            {
-              nodename << "G4HIT_ABSORBER_" << Name();
-            }
-          PHG4HitContainer* cylinder_hits =
-              findNode::getClass<PHG4HitContainer>(topNode,nodename.str());
-          if (!cylinder_hits)
-            {
-	      cylinder_hits =  new PHG4HitContainer(nodename.str());
-              dstNode->addNode(new PHIODataNode<PHObject>(cylinder_hits, nodename.str(), "PHObject"));
-            }
-          cylinder_hits->AddLayer(0);
-        }
-      steppingAction_ = new PHG4SpacalPrototypeSteppingAction(detector_);
+      nodename << "G4HIT_" << SuperDetector();
     }
+    else
+    {
+      nodename << "G4HIT_" << Name();
+    }
+    PHG4HitContainer* cylinder_hits = findNode::getClass<PHG4HitContainer>(
+        topNode, nodename.str());
+    if (!cylinder_hits)
+    {
+      dstNode->addNode(
+          new PHIODataNode<PHObject>(
+              cylinder_hits = new PHG4HitContainer(nodename.str()),
+              nodename.str(), "PHObject"));
+    }
+    cylinder_hits->AddLayer(0);
+    if (GetParams()->get_int_param("absorberactive"))
+    {
+      nodename.str("");
+      if (SuperDetector() != "NONE")
+      {
+        nodename << "G4HIT_ABSORBER_" << SuperDetector();
+      }
+      else
+      {
+        nodename << "G4HIT_ABSORBER_" << Name();
+      }
+      PHG4HitContainer* cylinder_hits =
+          findNode::getClass<PHG4HitContainer>(topNode, nodename.str());
+      if (!cylinder_hits)
+      {
+        cylinder_hits = new PHG4HitContainer(nodename.str());
+        dstNode->addNode(new PHIODataNode<PHObject>(cylinder_hits, nodename.str(), "PHObject"));
+      }
+      cylinder_hits->AddLayer(0);
+    }
+    steppingAction_ = new PHG4SpacalPrototypeSteppingAction(detector_);
+  }
 
   return 0;
-
 }
 
 //_______________________________________________________________________
-int
-PHG4SpacalPrototypeSubsystem::process_event(PHCompositeNode* topNode)
+int PHG4SpacalPrototypeSubsystem::process_event(PHCompositeNode* topNode)
 {
   // pass top node to stepping action so that it gets
   // relevant nodes needed internally
   if (steppingAction_)
-    {
-      steppingAction_->SetInterfacePointers(topNode);
-    }
+  {
+    steppingAction_->SetInterfacePointers(topNode);
+  }
   return 0;
-
 }
 
 //_______________________________________________________________________
@@ -121,33 +116,31 @@ PHG4SpacalPrototypeSubsystem::GetDetector(void) const
   return detector_;
 }
 
-void
-PHG4SpacalPrototypeSubsystem::Print(const std::string &what) const
+void PHG4SpacalPrototypeSubsystem::Print(const std::string& what) const
 {
   detector_->Print(what);
   cout << Name() << " Parameters: " << endl;
-  if (! BeginRunExecuted())
-    {
-      cout << "Need to execute BeginRun() before parameter printout is meaningful" << endl;
-      cout << "To do so either run one or more events or on the command line execute: " << endl;
-      cout << "Fun4AllServer *se = Fun4AllServer::instance();" << endl;
-      cout << "PHG4Reco *g4 = (PHG4Reco *) se->getSubsysReco(\"PHG4RECO\");" << endl;
-      cout << "g4->InitRun(se->topNode());" << endl;
-      cout << "PHG4SpacalPrototypeSubsystem *sys = (PHG4SpacalPrototypeSubsystem *) g4->getSubsystem(\"" << Name() << "\");" << endl;
-      cout << "sys->Print()" << endl;
-      return;
-    }
+  if (!BeginRunExecuted())
+  {
+    cout << "Need to execute BeginRun() before parameter printout is meaningful" << endl;
+    cout << "To do so either run one or more events or on the command line execute: " << endl;
+    cout << "Fun4AllServer *se = Fun4AllServer::instance();" << endl;
+    cout << "PHG4Reco *g4 = (PHG4Reco *) se->getSubsysReco(\"PHG4RECO\");" << endl;
+    cout << "g4->InitRun(se->topNode());" << endl;
+    cout << "PHG4SpacalPrototypeSubsystem *sys = (PHG4SpacalPrototypeSubsystem *) g4->getSubsystem(\"" << Name() << "\");" << endl;
+    cout << "sys->Print()" << endl;
+    return;
+  }
   GetParams()->Print();
   return;
 }
 
-void
-PHG4SpacalPrototypeSubsystem::SetDefaultParameters()
+void PHG4SpacalPrototypeSubsystem::SetDefaultParameters()
 {
-  set_default_double_param("xpos", 0.); // translation in 3D
-  set_default_double_param("ypos", 0.); // translation in 3D
-  set_default_double_param("zpos", 0.); // translation in 3D
-  set_default_double_param("z_rotation_degree", 0.); // roation in the vertical plane
-  set_default_int_param("construction_verbose", 0.); // roation in the vertical plane
+  set_default_double_param("xpos", 0.);               // translation in 3D
+  set_default_double_param("ypos", 0.);               // translation in 3D
+  set_default_double_param("zpos", 0.);               // translation in 3D
+  set_default_double_param("z_rotation_degree", 0.);  // roation in the vertical plane
+  set_default_int_param("construction_verbose", 0.);  // roation in the vertical plane
   return;
 }

--- a/simulation/g4simulation/g4caloprototype/PHG4SpacalPrototypeSubsystem.cc
+++ b/simulation/g4simulation/g4caloprototype/PHG4SpacalPrototypeSubsystem.cc
@@ -6,6 +6,8 @@
 
 #include <phparameter/PHParameters.h>
 
+#include <g4detectors/PHG4DetectorSubsystem.h>  // for PHG4DetectorSubsystem
+
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4SteppingAction.h>          // for PHG4SteppingAction
 
@@ -43,7 +45,7 @@ PHG4SpacalPrototypeSubsystem::InitRunSubsystem(PHCompositeNode* topNode)
     cout
         << "PHG4SpacalPrototypeSubsystem::InitRun - use PHG4SpacalPrototypeDetector"
         << endl;
-  detector_ = new PHG4SpacalPrototypeDetector(topNode, GetParams(), Name());
+  detector_ = new PHG4SpacalPrototypeDetector(this, topNode, GetParams(), Name());
 
   detector_->SetActive(GetParams()->get_int_param("active"));
   detector_->SetAbsorberActive(GetParams()->get_int_param("absorberactive"));


### PR DESCRIPTION
This PR accompanies the PR in the coresoftware. Currently all volumes are put into the world volume, hierarchical geometries like a cylinder inside a cylinder are not possible (think magnetic field inside a cylinder = beam magnets) on the macro level. A change in the PHG4Detector and PHG4Subsystem base classes enables this feature. These changes needed to be propagated to all detector implementations.
The main changes for users is that the Construct(G4LogicalVolume *world) method is now replaced by ConstructMe(G4LogicalVolume *world). The original methid os implemented in PHG4Detecto which exchanges the logical volume for the mother volume if it exists.