### PR TITLE
replace ifndef __CINT__ by if not defined (__CINT__) || defined(__CLING__) for rootcling

### DIFF
--- a/offline/packages/Prototype2/Prototype2DSTReader.h
+++ b/offline/packages/Prototype2/Prototype2DSTReader.h
@@ -66,7 +66,7 @@ class Prototype2DSTReader : public SubsysReco
 
   int nblocks;
 
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
 
   typedef std::shared_ptr<TClonesArray> arr_ptr;
 

--- a/offline/packages/Prototype3/Prototype3DSTReader.h
+++ b/offline/packages/Prototype3/Prototype3DSTReader.h
@@ -76,7 +76,7 @@ class Prototype3DSTReader : public SubsysReco
 
   int nblocks;
 
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
 
   typedef std::shared_ptr<TClonesArray> arr_ptr;
 

--- a/offline/packages/Prototype4/Prototype4DSTReader.h
+++ b/offline/packages/Prototype4/Prototype4DSTReader.h
@@ -76,7 +76,7 @@ class Prototype4DSTReader : public SubsysReco
 
   int nblocks;
 
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
 
   typedef std::shared_ptr<TClonesArray> arr_ptr;
 


### PR DESCRIPTION
This PR makes the include files completely accessible for rootcling. rootcling defines __CINT__ but also __CLING__ 
 !__CINT__ || __CLING__  allows rootcling to parse this but not rootcint