### PR TITLE
Gcc 8.3

### DIFF
--- a/offline/packages/Prototype3/Makefile.am
+++ b/offline/packages/Prototype3/Makefile.am
@@ -7,9 +7,6 @@ lib_LTLIBRARIES = \
   libPrototype3_io.la \
   libPrototype3.la
 
-AM_CXXFLAGS = \
- -Werror
-
 AM_CPPFLAGS = \
   -I$(includedir) \
   -I$(OFFLINE_MAIN)/include \

--- a/offline/packages/Prototype3/configure.ac
+++ b/offline/packages/Prototype3/configure.ac
@@ -10,11 +10,15 @@ case $CXX in
 # boost statistics
   CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-deprecated-declarations"
   ;;
-  g++)
-   CXXFLAGS="$CXXFLAGS -Wall -Werror"
-  ;;
 esac
 
+if test $ac_cv_prog_gxx = yes; then
+  if test `g++ -dumpversion | gawk '{print $1>=8.0?"1":"0"}'` = 1; then
+   CXXFLAGS="$CXXFLAGS -Wall -Wno-deprecated-declarations -Werror"
+  else
+   CXXFLAGS="$CXXFLAGS -Wall -Werror"
+  fi
+fi
 
 dnl test for root 6
 if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then

--- a/offline/packages/Prototype4/Makefile.am
+++ b/offline/packages/Prototype4/Makefile.am
@@ -7,9 +7,6 @@ lib_LTLIBRARIES = \
   libPrototype4_io.la \
   libPrototype4.la
 
-AM_CXXFLAGS = \
- -Werror
-
 AM_CPPFLAGS = \
   -I$(includedir) \
   -I$(OFFLINE_MAIN)/include \

--- a/offline/packages/Prototype4/configure.ac
+++ b/offline/packages/Prototype4/configure.ac
@@ -10,10 +10,16 @@ case $CXX in
 dnl boost accumulators
  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-deprecated-declarations"
  ;;
- g++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror"
- ;;
 esac
+
+dnl test for gcc 8.3
+if test $ac_cv_prog_gxx = yes; then
+  if test `g++ -dumpversion | gawk '{print $1>=8.0?"1":"0"}'` = 1; then
+   CXXFLAGS="$CXXFLAGS -Wall -Wno-deprecated-declarations -Werror"
+  else
+   CXXFLAGS="$CXXFLAGS -Wall -Werror"
+  fi
+fi
 
 dnl test for root 6
 if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then


### PR DESCRIPTION
This PR makes this compile with gcc 8.301, boost uses an obsolete container in the accumulators which creates a warning. Remove the duplicate setting of -Werror in the Makefile.am