### PR TITLE
Improving cluster analysis

### DIFF
--- a/macros/tpc2019/Fun4All_TestBeam_TPC.C
+++ b/macros/tpc2019/Fun4All_TestBeam_TPC.C
@@ -12,7 +12,6 @@
 
 #include <g4eval/PHG4DSTReader.h>
 #include <g4eval/SvtxEvaluator.h>
-#include <g4eval/TrkrEvaluator.h>
 
 #include <g4histos/G4HitNtuple.h>
 
@@ -66,7 +65,7 @@ int Fun4All_TestBeam_TPC(int nEvents = 10, int nSkip = 0,
                          //    const string &input_file = "data/tpc_beam/tpc_beam_00000191-0000.evt",  //readjusted HV to lwoer gain
                          //    const string &input_file = "data/tpc_beam/tpc_beam_00000217-0000.evt",  //moved beam to reduce drift
 //    const string &input_file = "data/tpc_beam/tpc_beam_00000241-0000.evt",  //moved beam to increase drift
-    const string &input_file = "data/tpc_beam/tpc_beam_00000274-0000.evt",  //moved beam to increase drift
+    const string &input_file = "data/tpc_beam/tpc_beam_00000300-0000.evt",  //moved beam to increase drift
                          bool eventDisp = false, int verbosity = 0)
 {
   gSystem->Load("libfun4all");

--- a/offline/packages/tpc2019/TpcPrototypeGenFitTrkFitter.cc
+++ b/offline/packages/tpc2019/TpcPrototypeGenFitTrkFitter.cc
@@ -64,7 +64,7 @@
 
 #include <TClonesArray.h>
 #include <TMatrixDSymfwd.h>  // for TMatrixDSym
-#include <TMatrixFfwd.h>                           // for TMatrixF
+#include <TMatrixFfwd.h>     // for TMatrixF
 #include <TMatrixT.h>        // for TMatrixT, operator*
 #include <TMatrixTSym.h>     // for TMatrixTSym
 #include <TMatrixTUtils.h>   // for TMatrixTRow
@@ -546,8 +546,8 @@ void TpcPrototypeGenFitTrkFitter::fill_eval_tree(PHCompositeNode* topNode)
   for (SvtxTrackMap::ConstIter itr = _trackmap->begin();
        itr != _trackmap->end(); ++itr)
   {
-//    new ((*_tca_trackmap)[i])(SvtxTrack_v1)(
-//        *dynamic_cast<SvtxTrack_v1*>(itr->second));
+    //    new ((*_tca_trackmap)[i])(SvtxTrack_v1)(
+    //        *dynamic_cast<SvtxTrack_v1*>(itr->second));
 
     new ((*_tca_tpctrackmap)[i])(TpcPrototypeTrack)(*(MakeTpcPrototypeTrack(itr->second)));
 
@@ -1142,6 +1142,7 @@ shared_ptr<TpcPrototypeTrack> TpcPrototypeGenFitTrkFitter::MakeTpcPrototypeTrack
   }
 
   shared_ptr<TpcPrototypeTrack> track(new TpcPrototypeTrack);
+  track->event = _event;
   track->trackID = svtxtrack->get_id();
   track->chisq = svtxtrack->get_chisq();
   track->ndf = svtxtrack->get_ndf();
@@ -1228,8 +1229,8 @@ shared_ptr<TpcPrototypeTrack> TpcPrototypeGenFitTrkFitter::MakeTpcPrototypeTrack
 
       TVector3 pos(cluster->getPosition(0), cluster->getPosition(1), cluster->getPosition(2));
 
-//      seed_mom.SetPhi(pos.Phi());
-//      seed_mom.SetTheta(pos.Theta());
+      //      seed_mom.SetPhi(pos.Phi());
+      //      seed_mom.SetTheta(pos.Theta());
 
       //TODO use u, v explicitly?
       TVector3 n(cluster->getPosition(0), cluster->getPosition(1), 0);
@@ -1321,7 +1322,11 @@ shared_ptr<TpcPrototypeTrack> TpcPrototypeGenFitTrkFitter::MakeTpcPrototypeTrack
         cout << ", azimuth_residual = " << azimuth_residual;
         cout << endl;
       }
-      assert(abs(n_residual) < 1e-4);//same layer check
+      assert(abs(n_residual) < 1e-4);  //same layer check
+
+      (track->clusterKey)[layerStudy] = cluster->getClusKey();
+      (track->clusterlayer)[layerStudy] = layerStudy;
+      (track->clusterid)[layerStudy] = TrkrDefs::getClusIndex(cluster->getClusKey());
 
       (track->clusterX)[layerStudy] = cluster->getPosition(0);
       (track->clusterY)[layerStudy] = cluster->getPosition(1);

--- a/offline/packages/tpc2019/TpcPrototypeTrack.cc
+++ b/offline/packages/tpc2019/TpcPrototypeTrack.cc
@@ -16,7 +16,8 @@
 using namespace std;
 
 TpcPrototypeTrack::TpcPrototypeTrack()
-  : trackID(-1)
+  : event(0)
+  , trackID(-1)
   , chisq(NAN)
   , ndf(0)
   , px(NAN)
@@ -29,6 +30,9 @@ TpcPrototypeTrack::TpcPrototypeTrack()
 {
   for (int i = 0; i < nLayer; ++i)
   {
+    clusterKey[i] = numeric_limits<uint64_t>::max();
+    clusterlayer[i] = -1;
+    clusterid[i] = -1;
     clusterX[i] = numeric_limits<float>::signaling_NaN();
     clusterY[i] = numeric_limits<float>::signaling_NaN();
     clusterZ[i] = numeric_limits<float>::signaling_NaN();

--- a/offline/packages/tpc2019/TpcPrototypeTrack.h
+++ b/offline/packages/tpc2019/TpcPrototypeTrack.h
@@ -26,6 +26,7 @@ class TpcPrototypeTrack : public PHObject
   //max number of layer under consideration
   static const int nLayer = 16;
 
+  unsigned int event;
   unsigned int trackID;
   float chisq;
   unsigned int ndf;
@@ -68,6 +69,9 @@ class TpcPrototypeTrack : public PHObject
   //  };
 
   //  Cluster clusters[nLayer];
+  uint64_t clusterKey[nLayer];
+  int clusterlayer[nLayer];
+  int clusterid[nLayer];
   float clusterX[nLayer];
   float clusterY[nLayer];
   float clusterZ[nLayer];
@@ -77,7 +81,7 @@ class TpcPrototypeTrack : public PHObject
   float clusterProjectionPhi[nLayer];
   float clusterResidualZ[nLayer];
 
-  ClassDef(TpcPrototypeTrack, 4);
+  ClassDef(TpcPrototypeTrack, 5);
 };
 
 #endif /* TPCPROTOTYPETRACK_H_ */

--- a/offline/packages/tpc2019/TpcPrototypeUnpacker.cc
+++ b/offline/packages/tpc2019/TpcPrototypeUnpacker.cc
@@ -7,8 +7,8 @@
 
 #include "TpcPrototypeUnpacker.h"
 
-#include "TpcPrototypeDefs.h"
 #include "ChanMap.h"
+#include "TpcPrototypeDefs.h"
 
 #include <g4tpc/PHG4TpcPadPlane.h>  // for PHG4TpcPadPlane
 
@@ -24,7 +24,7 @@
 #include <fun4all/PHTFileServer.h>
 #include <fun4all/SubsysReco.h>
 
-#include <phfield/PHFieldConfig.h>                              // for PHFie...
+#include <phfield/PHFieldConfig.h>  // for PHFie...
 #include <phfield/PHFieldConfigv2.h>
 #include <phfield/PHFieldUtility.h>
 
@@ -33,24 +33,24 @@
 #include <trackbase/TrkrDefs.h>  // for hitkey, getLayer
 
 #include <phool/PHCompositeNode.h>
-#include <phool/PHIODataNode.h>                                 // for PHIOD...
-#include <phool/PHNode.h>                                       // for PHNode
-#include <phool/PHNodeIterator.h>                               // for PHNod...
-#include <phool/PHObject.h>                                     // for PHObject
+#include <phool/PHIODataNode.h>    // for PHIOD...
+#include <phool/PHNode.h>          // for PHNode
+#include <phool/PHNodeIterator.h>  // for PHNod...
+#include <phool/PHObject.h>        // for PHObject
 #include <phool/getClass.h>
-#include <phool/phool.h>                                        // for PHWHERE
+#include <phool/phool.h>  // for PHWHERE
 
 #include <Event/Event.h>
 #include <Event/EventTypes.h>
 #include <Event/packet.h>
 
-#include <TAxis.h>                                              // for TAxis
+#include <TAxis.h>  // for TAxis
 #include <TClonesArray.h>
-#include <TH1.h>                                                // for TH1D
-#include <TMatrixFfwd.h>                                        // for TMatrixF
-#include <TMatrixT.h>                                           // for TMatrixT
-#include <TMatrixTUtils.h>                                      // for TMatr...
-#include <TNamed.h>                                             // for TNamed
+#include <TH1.h>            // for TH1D
+#include <TMatrixFfwd.h>    // for TMatrixF
+#include <TMatrixT.h>       // for TMatrixT
+#include <TMatrixTUtils.h>  // for TMatr...
+#include <TNamed.h>         // for TNamed
 #include <TTree.h>
 
 #include <boost/bimap.hpp>
@@ -62,13 +62,13 @@
 #include <algorithm>
 #include <cassert>
 #include <cmath>
-#include <cstdint>                                              // for uint32_t
+#include <cstdint>  // for uint32_t
 #include <iostream>
-#include <iterator>                                             // for rever...
+#include <iterator>  // for rever...
 #include <map>
+#include <memory>
 #include <sstream>
 #include <stdexcept>
-#include <memory>
 
 class PHField;
 
@@ -153,20 +153,15 @@ void TpcPrototypeUnpacker::ClusterData::Clear(Option_t*)
     pad_azimuth_samples.erase(pad_azimuth_samples.begin());
   }
 
-  while (pad_radial_peaks.begin() != pad_radial_peaks.end())
-  {
-    pad_radial_peaks.erase(pad_radial_peaks.begin());
-  }
-
   while (pad_azimuth_peaks.begin() != pad_azimuth_peaks.end())
   {
     pad_azimuth_peaks.erase(pad_azimuth_peaks.begin());
   }
 
-//  while (sum_samples.begin() != sum_samples.end())
-//  {
-//    sum_samples.erase(sum_samples.begin());
-//  }
+  //  while (sum_samples.begin() != sum_samples.end())
+  //  {
+  //    sum_samples.erase(sum_samples.begin());
+  //  }
   sum_samples.clear();
   sum_samples.shrink_to_fit();
 }
@@ -748,7 +743,7 @@ int TpcPrototypeUnpacker::Clustering()
     ClusterData& cluster = m_clusters[iter.second];
 
     //output to DST clusters
-    cluster.clusterID = m_nClusters; // sync cluster id from cluster container to m_nClusters::ClusterData
+    cluster.clusterID = m_nClusters;  // sync cluster id from cluster container to m_nClusters::ClusterData
     int ret = exportDSTCluster(cluster, m_nClusters);
     if (ret != Fun4AllReturnCodes::EVENT_OK) return ret;
 
@@ -812,7 +807,7 @@ int TpcPrototypeUnpacker::exportDSTCluster(ClusterData& cluster, const int iclus
   const double clusz = layergeom->get_zcenter(cluster.min_sample)  //
                        + (layergeom->get_zcenter(cluster.min_sample + 1) - layergeom->get_zcenter(cluster.min_sample)) * cluster.peak_sample;
 
-  const double phi_size = cluster.size_pad_azimuth;                       // * radius * layergeom->get_phistep();
+  const double phi_size = cluster.size_pad_azimuth;                 // * radius * layergeom->get_phistep();
   const double z_size = (cluster.max_sample - cluster.min_sample);  // * layergeom->get_zstep();
 
   static const double phi_err = 170e-4;
@@ -831,6 +826,9 @@ int TpcPrototypeUnpacker::exportDSTCluster(ClusterData& cluster, const int iclus
   cluster.avg_pos_x = clus->getPosition(0);
   cluster.avg_pos_y = clus->getPosition(1);
   cluster.avg_pos_z = clus->getPosition(2);
+
+  cluster.delta_z = (layergeom->get_zcenter(cluster.min_sample + 1) - layergeom->get_zcenter(cluster.min_sample));
+  cluster.delta_azimuth_bin = (layergeom->get_phicenter(lowery + 1) - layergeom->get_phicenter(lowery));
 
   TMatrixF DIM(3, 3);
   DIM[0][0] = 0.0;

--- a/offline/packages/tpc2019/TpcPrototypeUnpacker.cc
+++ b/offline/packages/tpc2019/TpcPrototypeUnpacker.cc
@@ -724,6 +724,9 @@ int TpcPrototypeUnpacker::Clustering()
       }
       cluster.avg_pad_azimuth = sum_peak_pad_azimuth / sum_peak;
       cluster.size_pad_azimuth = cluster.pad_azimuths.size();
+
+      cluster.min_pad_azimuth = *cluster.pad_azimuths.begin();
+      cluster.max_pad_azimuth = *cluster.pad_azimuths.rbegin();
     }
   }  //   for (auto& iter : m_clusters)
 

--- a/offline/packages/tpc2019/TpcPrototypeUnpacker.cc
+++ b/offline/packages/tpc2019/TpcPrototypeUnpacker.cc
@@ -131,36 +131,36 @@ int TpcPrototypeUnpacker::ResetEvent(PHCompositeNode* topNode)
 
 void TpcPrototypeUnpacker::ClusterData::Clear(Option_t*)
 {
-  padxs.clear();
-  padys.clear();
+  pad_radials.clear();
+  pad_azimuths.clear();
   samples.clear();
 
-  //  for (auto& s : padx_samples) s.second.clear();
-  //  padx_samples.clear();
+  //  for (auto& s : pad_radial_samples) s.second.clear();
+  //  pad_radial_samples.clear();
   //
-  //  for (auto& s : pady_samples) s.second.clear();
-  //  pady_samples.clear();
+  //  for (auto& s : pad_azimuth_samples) s.second.clear();
+  //  pad_azimuth_samples.clear();
 
-  while (padx_samples.begin() != padx_samples.end())
+  while (pad_radial_samples.begin() != pad_radial_samples.end())
   {
-    padx_samples.begin()->second.clear();
-    padx_samples.erase(padx_samples.begin());
+    pad_radial_samples.begin()->second.clear();
+    pad_radial_samples.erase(pad_radial_samples.begin());
   }
 
-  while (pady_samples.begin() != pady_samples.end())
+  while (pad_azimuth_samples.begin() != pad_azimuth_samples.end())
   {
-    pady_samples.begin()->second.clear();
-    pady_samples.erase(pady_samples.begin());
+    pad_azimuth_samples.begin()->second.clear();
+    pad_azimuth_samples.erase(pad_azimuth_samples.begin());
   }
 
-  while (padx_peaks.begin() != padx_peaks.end())
+  while (pad_radial_peaks.begin() != pad_radial_peaks.end())
   {
-    padx_peaks.erase(padx_peaks.begin());
+    pad_radial_peaks.erase(pad_radial_peaks.begin());
   }
 
-  while (pady_peaks.begin() != pady_peaks.end())
+  while (pad_azimuth_peaks.begin() != pad_azimuth_peaks.end())
   {
-    pady_peaks.erase(pady_peaks.begin());
+    pad_azimuth_peaks.erase(pad_azimuth_peaks.begin());
   }
 
 //  while (sum_samples.begin() != sum_samples.end())
@@ -603,8 +603,8 @@ int TpcPrototypeUnpacker::Clustering()
   {
     const int& i = iter.first;
     const PadPlaneData::SampleID& id = iter.second;
-    m_clusters[i].padxs.insert(id.padx);
-    m_clusters[i].padys.insert(id.pady);
+    m_clusters[i].pad_radials.insert(id.pad_radial);
+    m_clusters[i].pad_azimuths.insert(id.pad_azimuth);
     m_clusters[i].samples.insert(id.sample);
   }
 
@@ -613,33 +613,33 @@ int TpcPrototypeUnpacker::Clustering()
   {
     ClusterData& cluster = iter.second;
 
-    assert(cluster.padxs.size() > 0);
-    assert(cluster.padys.size() > 0);
+    assert(cluster.pad_radials.size() > 0);
+    assert(cluster.pad_azimuths.size() > 0);
     assert(cluster.samples.size() > 0);
 
     //expand cluster by +/-1 in y
-    if (*(cluster.padys.begin()) - 1 >= 0)
-      cluster.padys.insert(*(cluster.padys.begin()) - 1);
-    if (*(cluster.padys.rbegin()) + 1 < (int) kMaxPadY)
-      cluster.padys.insert(*(cluster.padys.rbegin()) + 1);
+    if (*(cluster.pad_azimuths.begin()) - 1 >= 0)
+      cluster.pad_azimuths.insert(*(cluster.pad_azimuths.begin()) - 1);
+    if (*(cluster.pad_azimuths.rbegin()) + 1 < (int) kMaxPadY)
+      cluster.pad_azimuths.insert(*(cluster.pad_azimuths.rbegin()) + 1);
 
     cluster.min_sample = max(0, *cluster.samples.begin() - m_nPreSample);
     cluster.max_sample = min((int) (kSAMPLE_LENGTH) -1, *cluster.samples.rbegin() + m_nPostSample);
     const int n_sample = cluster.max_sample - cluster.min_sample + 1;
 
     cluster.sum_samples.assign(n_sample, 0);
-    for (int pad_x = *cluster.padxs.begin(); pad_x <= *cluster.padxs.rbegin(); ++pad_x)
+    for (int pad_x = *cluster.pad_radials.begin(); pad_x <= *cluster.pad_radials.rbegin(); ++pad_x)
     {
-      cluster.padx_samples[pad_x].assign(n_sample, 0);
+      cluster.pad_radial_samples[pad_x].assign(n_sample, 0);
     }
-    for (int pad_y = *cluster.padys.begin(); pad_y <= *cluster.padys.rbegin(); ++pad_y)
+    for (int pad_y = *cluster.pad_azimuths.begin(); pad_y <= *cluster.pad_azimuths.rbegin(); ++pad_y)
     {
-      cluster.pady_samples[pad_y].assign(n_sample, 0);
+      cluster.pad_azimuth_samples[pad_y].assign(n_sample, 0);
     }
 
-    for (int pad_x = *cluster.padxs.begin(); pad_x <= *cluster.padxs.rbegin(); ++pad_x)
+    for (int pad_x = *cluster.pad_radials.begin(); pad_x <= *cluster.pad_radials.rbegin(); ++pad_x)
     {
-      for (int pad_y = *cluster.padys.begin(); pad_y <= *cluster.padys.rbegin(); ++pad_y)
+      for (int pad_y = *cluster.pad_azimuths.begin(); pad_y <= *cluster.pad_azimuths.rbegin(); ++pad_y)
       {
         assert(m_padPlaneData.IsValidPad(pad_x, pad_y));
 
@@ -649,13 +649,13 @@ int TpcPrototypeUnpacker::Clustering()
         {
           int adc = padsamples.at(cluster.min_sample + i);
           cluster.sum_samples[i] += adc;
-          cluster.padx_samples[pad_x][i] += adc;
-          cluster.pady_samples[pad_y][i] += adc;
+          cluster.pad_radial_samples[pad_x][i] += adc;
+          cluster.pad_azimuth_samples[pad_y][i] += adc;
         }
 
-      }  //    	    for (int pad_y = *cluster.padys.begin(); pad_y<=*cluster.padys.rbegin() ;++pady)
+      }  //    	    for (int pad_y = *cluster.pad_azimuths.begin(); pad_y<=*cluster.pad_azimuths.rbegin() ;++pad_azimuth)
 
-    }  //    for (int pad_x = *cluster.padxs.begin(); pad_x<=*cluster.padxs.rbegin() ;++padx)
+    }  //    for (int pad_x = *cluster.pad_radials.begin(); pad_x<=*cluster.pad_radials.rbegin() ;++pad_radial)
 
     if (m_pdfMaker)
     {
@@ -683,52 +683,52 @@ int TpcPrototypeUnpacker::Clustering()
       cluster.pedstal = pedstal;
     }
 
-    // fit - X
+    // fit - X -> radial direction
     {
       //      double sum_peak = 0;
-      //      double sum_peak_padx = 0;
-      //      for (int pad_x = *cluster.padxs.begin(); pad_x <= *cluster.padxs.rbegin(); ++pad_x)
+      //      double sum_peak_pad_radial = 0;
+      //      for (int pad_x = *cluster.pad_radials.begin(); pad_x <= *cluster.pad_radials.rbegin(); ++pad_x)
       //      {
       //        double peak = NAN;
       //        double peak_sample = NAN;
       //        double pedstal = NAN;
       //        map<int, double> parameters_io(parameters_constraints);
       //
-      //        SampleFit_PowerLawDoubleExp(cluster.padx_samples[pad_x], peak,
+      //        SampleFit_PowerLawDoubleExp(cluster.pad_radial_samples[pad_x], peak,
       //                                    peak_sample, pedstal, parameters_io, Verbosity());
       //
-      //        cluster.padx_peaks[pad_x] = peak;
+      //        cluster.pad_radial_peaks[pad_x] = peak;
       //        sum_peak += peak;
-      //        sum_peak_padx += peak * pad_x;
+      //        sum_peak_pad_radial += peak * pad_x;
       //      }
-      //      cluster.avg_padx = sum_peak_padx / sum_peak;
-      //      cluster.size_pad_x = cluster.padxs.size();
+      //      cluster.avg_pad_radial = sum_peak_pad_radial / sum_peak;
+      //      cluster.size_pad_radial = cluster.pad_radials.size();
 
-      assert(cluster.padxs.size() == 1);
-      cluster.avg_padx = *cluster.padxs.begin();
-      cluster.size_pad_x = cluster.padxs.size();
+      assert(cluster.pad_radials.size() == 1);
+      cluster.avg_pad_radial = *cluster.pad_radials.begin();
+      cluster.size_pad_radial = cluster.pad_radials.size();
     }
 
-    // fit - Y
+    // fit - Y -> azimuthal direction
     {
       double sum_peak = 0;
-      double sum_peak_pady = 0;
-      for (int pad_y = *cluster.padys.begin(); pad_y <= *cluster.padys.rbegin(); ++pad_y)
+      double sum_peak_pad_azimuth = 0;
+      for (int pad_y = *cluster.pad_azimuths.begin(); pad_y <= *cluster.pad_azimuths.rbegin(); ++pad_y)
       {
         double peak = NAN;
         double peak_sample = NAN;
         double pedstal = NAN;
         map<int, double> parameters_io(parameters_constraints);
 
-        SampleFit_PowerLawDoubleExp(cluster.pady_samples[pad_y], peak,
+        SampleFit_PowerLawDoubleExp(cluster.pad_azimuth_samples[pad_y], peak,
                                     peak_sample, pedstal, parameters_io, Verbosity());
 
-        cluster.pady_peaks[pad_y] = peak;
+        cluster.pad_azimuth_peaks[pad_y] = peak;
         sum_peak += peak;
-        sum_peak_pady += peak * pad_y;
+        sum_peak_pad_azimuth += peak * pad_y;
       }
-      cluster.avg_pady = sum_peak_pady / sum_peak;
-      cluster.size_pad_y = cluster.padys.size();
+      cluster.avg_pad_azimuth = sum_peak_pad_azimuth / sum_peak;
+      cluster.size_pad_azimuth = cluster.pad_azimuths.size();
     }
   }  //   for (auto& iter : m_clusters)
 
@@ -762,9 +762,9 @@ int TpcPrototypeUnpacker::exportDSTCluster(ClusterData& cluster, const int iclus
   assert(tpcCylinderCellGeom);
   assert(trkrclusters);
 
-  assert(cluster.avg_padx >= 0);
-  assert(cluster.avg_padx < (int) kMaxPadX);
-  const uint8_t layer = static_cast<uint8_t>(cluster.avg_padx);
+  assert(cluster.avg_pad_radial >= 0);
+  assert(cluster.avg_pad_radial < (int) kMaxPadX);
+  const uint8_t layer = static_cast<uint8_t>(cluster.avg_pad_radial);
   const PHG4CylinderCellGeom* layergeom = tpcCylinderCellGeom->GetLayerCellGeom(layer);
   const int NPhiBins = layergeom->get_phibins();
   const int NZBins = layergeom->get_zbins();
@@ -777,41 +777,41 @@ int TpcPrototypeUnpacker::exportDSTCluster(ClusterData& cluster, const int iclus
 
   //  calculate geometry
   const double radius = layergeom->get_radius();  // returns center of layer
-  if (cluster.avg_pady < 0)
+  if (cluster.avg_pad_azimuth < 0)
   {
-    cout << __PRETTY_FUNCTION__ << " WARNING - cluster.avg_pady = " << cluster.avg_pady << " < 0"
-         << ", cluster.avg_padx = " << cluster.avg_padx << endl;
+    cout << __PRETTY_FUNCTION__ << " WARNING - cluster.avg_pad_azimuth = " << cluster.avg_pad_azimuth << " < 0"
+         << ", cluster.avg_pad_radial = " << cluster.avg_pad_radial << endl;
 
     return Fun4AllReturnCodes::ABORTEVENT;
   }
-  if (cluster.avg_pady >= NPhiBins)
+  if (cluster.avg_pad_azimuth >= NPhiBins)
   {
-    cout << __PRETTY_FUNCTION__ << " WARNING - cluster.avg_pady = " << cluster.avg_pady << " > " << NPhiBins
-         << ", cluster.avg_padx = " << cluster.avg_padx << endl;
+    cout << __PRETTY_FUNCTION__ << " WARNING - cluster.avg_pad_azimuth = " << cluster.avg_pad_azimuth << " > " << NPhiBins
+         << ", cluster.avg_pad_radial = " << cluster.avg_pad_radial << endl;
 
     return Fun4AllReturnCodes::ABORTEVENT;
   }
-  const int lowery = floor(cluster.avg_pady);
+  const int lowery = floor(cluster.avg_pad_azimuth);
 
   if (lowery < 0)
   {
-    cout << __PRETTY_FUNCTION__ << " WARNING - cluster.avg_pady = " << cluster.avg_pady << " -> "
+    cout << __PRETTY_FUNCTION__ << " WARNING - cluster.avg_pad_azimuth = " << cluster.avg_pad_azimuth << " -> "
          << " lower = " << lowery << " < 0"
-         << ", cluster.avg_padx = " << cluster.avg_padx << endl;
+         << ", cluster.avg_pad_radial = " << cluster.avg_pad_radial << endl;
 
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
   const double clusphi = layergeom->get_phicenter(lowery)                                             //
                          + (layergeom->get_phicenter(lowery + 1) - layergeom->get_phicenter(lowery))  //
-                               * (cluster.avg_pady - lowery);
+                               * (cluster.avg_pad_azimuth - lowery);
 
   assert(cluster.min_sample >= 0);
   assert(cluster.min_sample + cluster.peak_sample < NZBins);
   const double clusz = layergeom->get_zcenter(cluster.min_sample)  //
                        + (layergeom->get_zcenter(cluster.min_sample + 1) - layergeom->get_zcenter(cluster.min_sample)) * cluster.peak_sample;
 
-  const double phi_size = cluster.size_pad_y;                       // * radius * layergeom->get_phistep();
+  const double phi_size = cluster.size_pad_azimuth;                       // * radius * layergeom->get_phistep();
   const double z_size = (cluster.max_sample - cluster.min_sample);  // * layergeom->get_zstep();
 
   static const double phi_err = 170e-4;
@@ -957,17 +957,17 @@ std::pair<int, int> TpcPrototypeUnpacker::roughZeroSuppression(std::vector<int>&
 
 bool operator<(const TpcPrototypeUnpacker::PadPlaneData::SampleID& s1, const TpcPrototypeUnpacker::PadPlaneData::SampleID& s2)
 {
-  if (s1.pady == s2.pady)
+  if (s1.pad_azimuth == s2.pad_azimuth)
   {
-    if (s1.padx == s2.padx)
+    if (s1.pad_radial == s2.pad_radial)
     {
       return s1.sample < s2.sample;
     }
     else
-      return s1.padx < s2.padx;
+      return s1.pad_radial < s2.pad_radial;
   }
   else
-    return s1.pady < s2.pady;
+    return s1.pad_azimuth < s2.pad_azimuth;
 }
 
 //! 3-D Graph clustering based on PHMakeGroups()
@@ -980,15 +980,15 @@ void TpcPrototypeUnpacker::PadPlaneData::Clustering(int zero_suppression, bool v
   Graph G;
   VertexList vertex_list;
 
-  for (unsigned int pady = 0; pady < kMaxPadY; ++pady)
+  for (unsigned int pad_azimuth = 0; pad_azimuth < kMaxPadY; ++pad_azimuth)
   {
-    for (unsigned int padx = 0; padx < kMaxPadX; ++padx)
+    for (unsigned int pad_radial = 0; pad_radial < kMaxPadX; ++pad_radial)
     {
       for (unsigned int sample = 0; sample < kSAMPLE_LENGTH; sample++)
       {
-        if (m_data[pady][padx][sample] > zero_suppression)
+        if (m_data[pad_azimuth][pad_radial][sample] > zero_suppression)
         {
-          SampleID id{(int) (pady), (int) (padx), (int) (sample)};
+          SampleID id{(int) (pad_azimuth), (int) (pad_radial), (int) (sample)};
           Graph::vertex_descriptor v = boost::add_vertex(G);
           vertex_list.insert(VertexList::value_type(v, id));
 
@@ -996,7 +996,7 @@ void TpcPrototypeUnpacker::PadPlaneData::Clustering(int zero_suppression, bool v
         }
       }  //      for (unsigned int sample = 0; sample < kSAMPLE_LENGTH; sample++)
     }
-  }  //   for (unsigned int pady = 0; pady < kMaxPadY; ++pady)
+  }  //   for (unsigned int pad_azimuth = 0; pad_azimuth < kMaxPadY; ++pad_azimuth)
 
   // connect 2-D adjacent samples within each pad_x
   vector<SampleID> search_directions;
@@ -1050,7 +1050,7 @@ void TpcPrototypeUnpacker::PadPlaneData::Clustering(int zero_suppression, bool v
       for (auto iter = range.first; iter != range.second; ++iter)
       {
         const SampleID& id = iter->second;
-        cout << "adc[" << id.pady << "][" << id.padx << "][" << id.sample << "] = " << m_data[id.pady][id.padx][id.sample] << ", ";
+        cout << "adc[" << id.pad_azimuth << "][" << id.pad_radial << "][" << id.sample << "] = " << m_data[id.pad_azimuth][id.pad_radial][id.sample] << ", ";
       }
       cout << endl;
     }  //  for (const int& comp : comps)

--- a/offline/packages/tpc2019/TpcPrototypeUnpacker.cc
+++ b/offline/packages/tpc2019/TpcPrototypeUnpacker.cc
@@ -748,6 +748,7 @@ int TpcPrototypeUnpacker::Clustering()
     ClusterData& cluster = m_clusters[iter.second];
 
     //output to DST clusters
+    cluster.clusterID = m_nClusters; // sync cluster id from cluster container to m_nClusters::ClusterData
     int ret = exportDSTCluster(cluster, m_nClusters);
     if (ret != Fun4AllReturnCodes::EVENT_OK) return ret;
 

--- a/offline/packages/tpc2019/TpcPrototypeUnpacker.h
+++ b/offline/packages/tpc2019/TpcPrototypeUnpacker.h
@@ -160,6 +160,8 @@ class TpcPrototypeUnpacker : public SubsysReco
       , avg_pos_x(NAN)
       , avg_pos_y(NAN)
       , avg_pos_z(NAN)
+      , delta_azimuth_bin(NAN)
+      , delta_z(NAN)
     {
     }
 
@@ -189,7 +191,7 @@ class TpcPrototypeUnpacker : public SubsysReco
     int avg_pad_radial;
     double avg_pad_azimuth;
 
-    //! pad size
+    //! cluster size in units of pad bins
     int size_pad_radial;
     int size_pad_azimuth;
 
@@ -197,6 +199,12 @@ class TpcPrototypeUnpacker : public SubsysReco
     double avg_pos_x;
     double avg_pos_y;
     double avg_pos_z;
+
+    //! pad bin size
+    //! phi size per pad in rad
+    double delta_azimuth_bin;
+    //! z size per ADC sample bin
+    double delta_z;
 
     ClassDef(TpcPrototypeUnpacker::ClusterData, 5);
   };

--- a/offline/packages/tpc2019/TpcPrototypeUnpacker.h
+++ b/offline/packages/tpc2019/TpcPrototypeUnpacker.h
@@ -17,7 +17,7 @@
 #include <map>
 #include <set>
 #include <string>
-#include <utility>               // for pair
+#include <utility>  // for pair
 #include <vector>
 
 class PHCompositeNode;
@@ -121,7 +121,7 @@ class TpcPrototypeUnpacker : public SubsysReco
     //! 3-D Graph clustering based on PHMakeGroups()
     void Clustering(int zero_suppression, bool verbosity = false);
 
-#if !defined(__CINT__) || defined (__CLING__)
+#if !defined(__CINT__) || defined(__CLING__)
 
     const std::vector<std::vector<std::vector<int>>> &getData() const
     {
@@ -147,7 +147,8 @@ class TpcPrototypeUnpacker : public SubsysReco
   {
    public:
     ClusterData()
-      : min_sample(-1)
+      : clusterID(-1)
+      , min_sample(-1)
       , max_sample(-1)
       , peak(NAN)
       , peak_sample(NAN)
@@ -164,6 +165,8 @@ class TpcPrototypeUnpacker : public SubsysReco
 
     void Clear(Option_t * /*option*/ = "");
 
+    int clusterID;
+
     std::set<int> pad_radials;
     std::set<int> pad_azimuths;
     std::set<int> samples;
@@ -179,7 +182,7 @@ class TpcPrototypeUnpacker : public SubsysReco
     double peak_sample;
     double pedstal;
 
-//    std::map<int, double> pad_radial_peaks; // radial always have size = 1 in this analysis
+    //    std::map<int, double> pad_radial_peaks; // radial always have size = 1 in this analysis
     std::map<int, double> pad_azimuth_peaks;
 
     //! pad coordinate
@@ -249,7 +252,7 @@ class TpcPrototypeUnpacker : public SubsysReco
   int exportDSTCluster(ClusterData &cluster, const int i);
   int InitField(PHCompositeNode *topNode);
 
-#if !defined(__CINT__) || defined (__CLING__)
+#if !defined(__CINT__) || defined(__CLING__)
 
   // IO stuff
 

--- a/offline/packages/tpc2019/TpcPrototypeUnpacker.h
+++ b/offline/packages/tpc2019/TpcPrototypeUnpacker.h
@@ -150,6 +150,8 @@ class TpcPrototypeUnpacker : public SubsysReco
       : clusterID(-1)
       , min_sample(-1)
       , max_sample(-1)
+      , min_pad_azimuth(-1)
+      , max_pad_azimuth(-1)
       , peak(NAN)
       , peak_sample(NAN)
       , pedstal(NAN)
@@ -179,6 +181,8 @@ class TpcPrototypeUnpacker : public SubsysReco
 
     int min_sample;
     int max_sample;
+    int min_pad_azimuth;
+    int max_pad_azimuth;
 
     double peak;
     double peak_sample;

--- a/offline/packages/tpc2019/TpcPrototypeUnpacker.h
+++ b/offline/packages/tpc2019/TpcPrototypeUnpacker.h
@@ -102,14 +102,14 @@ class TpcPrototypeUnpacker : public SubsysReco
 
     struct SampleID
     {
-      int pady;
-      int padx;
+      int pad_azimuth;
+      int pad_radial;
       int sample;
 
       void adjust(const SampleID &adjustment)
       {
-        pady += adjustment.pady;
-        padx += adjustment.padx;
+        pad_azimuth += adjustment.pad_azimuth;
+        pad_radial += adjustment.pad_radial;
         sample += adjustment.sample;
       }
     };
@@ -134,7 +134,7 @@ class TpcPrototypeUnpacker : public SubsysReco
     }
 
    private:
-    //! full event data in index order of m_data[pady][padx][sample]
+    //! full event data in index order of m_data[pad_azimuth][pad_radial][sample]
     std::vector<std::vector<std::vector<int>>> m_data;
 
     std::multimap<int, SampleID> m_groups;
@@ -152,10 +152,10 @@ class TpcPrototypeUnpacker : public SubsysReco
       , peak(NAN)
       , peak_sample(NAN)
       , pedstal(NAN)
-      , avg_padx(-1)
-      , avg_pady(NAN)
-      , size_pad_x(-1)
-      , size_pad_y(-1)
+      , avg_pad_radial(-1)
+      , avg_pad_azimuth(NAN)
+      , size_pad_radial(-1)
+      , size_pad_azimuth(-1)
       , avg_pos_x(NAN)
       , avg_pos_y(NAN)
       , avg_pos_z(NAN)
@@ -164,12 +164,12 @@ class TpcPrototypeUnpacker : public SubsysReco
 
     void Clear(Option_t * /*option*/ = "");
 
-    std::set<int> padxs;
-    std::set<int> padys;
+    std::set<int> pad_radials;
+    std::set<int> pad_azimuths;
     std::set<int> samples;
 
-    std::map<int, std::vector<double>> padx_samples;
-    std::map<int, std::vector<double>> pady_samples;
+    std::map<int, std::vector<double>> pad_radial_samples;
+    std::map<int, std::vector<double>> pad_azimuth_samples;
     std::vector<double> sum_samples;
 
     int min_sample;
@@ -179,23 +179,23 @@ class TpcPrototypeUnpacker : public SubsysReco
     double peak_sample;
     double pedstal;
 
-    std::map<int, double> padx_peaks;
-    std::map<int, double> pady_peaks;
+//    std::map<int, double> pad_radial_peaks; // radial always have size = 1 in this analysis
+    std::map<int, double> pad_azimuth_peaks;
 
     //! pad coordinate
-    int avg_padx;
-    double avg_pady;
+    int avg_pad_radial;
+    double avg_pad_azimuth;
 
     //! pad size
-    int size_pad_x;
-    int size_pad_y;
+    int size_pad_radial;
+    int size_pad_azimuth;
 
     //! pad coordinate
     double avg_pos_x;
     double avg_pos_y;
     double avg_pos_z;
 
-    ClassDef(TpcPrototypeUnpacker::ClusterData, 3);
+    ClassDef(TpcPrototypeUnpacker::ClusterData, 5);
   };
 
   //! simple channel header class for ROOT file IO


### PR DESCRIPTION
Following request from @shulga ,  and adding a few features to the evaluation output for cluster studies of 2019 TPC test beam

# 1. track -> cluster association

Full track fitting information `TpcPrototypeGenFitTrkFitter.root`. The clusters associated with the track can be identified with `TPCTrack.event` and `TPCTrack.clusterid`.

Full info on cluster is at `TpcPrototypeGenFitTrkFitter.root`, where the clusters can be matched with `event` and `Clusters.clusterID` 

## Example prints from run 300 is shown here. 

### `TpcPrototypeGenFitTrkFitter.root`
```
root
root [0] 
root [0] gSystem->Load("libtpc2019")
(int) 0
root [1] TFile::Open("data/tpc_beam/tpc_beam_00000300-0000.evt_TpcPrototypeGenFitTrkFitter.root")
(TFile *) 0x24f7460
root [2] T->Scan("event")
***********************************
*    Row   * Instance *     event *
***********************************
*        0 *        0 *           *
*        1 *        0 *         2 *
*        2 *        0 *           *
*        3 *        0 *           *
*        4 *        0 *         5 *
*        5 *        0 *           *
*        6 *        0 *           *
*        7 *        0 *         8 *
*        8 *        0 *         9 *
*        9 *        0 *        10 *
*        9 *        1 *        10 *
***********************************
(long long) 11
root [3] T->Show(1)
======> EVENT:1
 nTrack          = 1
 TPCTrack        = 1
 TPCTrack.fUniqueID = 0
 TPCTrack.fBits  = 50331648
 TPCTrack.event  = 2
 TPCTrack.trackID = 0
 TPCTrack.chisq  = 14.413390
 TPCTrack.ndf    = 8
 TPCTrack.px     = -97.363541
 TPCTrack.py     = -22.807943
 TPCTrack.pz     = 0.371238
 TPCTrack.x      = 0.087810
 TPCTrack.y      = -0.573704
 TPCTrack.z      = -12.217271
 TPCTrack.nCluster = 8
 TPCTrack.clusterKey[16] = 144115188075855913 , 144396663052566555 , 144678138029277204 , 144959613005987840 , 145241087982698518 , 
                    145522562959409181 , 145804037936119820 , 146085512912830466 , 18446744073709551615 , 18446744073709551615 , 
                    18446744073709551615 , 18446744073709551615 , 18446744073709551615 , 18446744073709551615 , 18446744073709551615 , 
                    18446744073709551615 

 TPCTrack.clusterlayer[16] = 0 , 1 , 2 , 3 , 4 , 5 , 6 , 7 , -1 , -1 , 
                    -1 , -1 , -1 , -1 , -1 , -1 

 TPCTrack.clusterid[16] = 41 , 27 , 20 , 0 , 22 , 29 , 12 , 2 , -1 , -1 , 
                    -1 , -1 , -1 , -1 , -1 , -1 

 TPCTrack.clusterX[16] = -39.464973 , -40.634251 , -41.859875 , -43.058498 , -44.289875 , 
                    -45.508629 , -46.718132 , -47.938789 , nan , nan , 
                    nan , nan , nan , nan , nan , 
                    nan 

 TPCTrack.clusterY[16] = -9.638797 , -10.117970 , -10.369010 , -10.728765 , -10.956621 , 
                    -11.235226 , -11.551269 , -11.822140 , nan , nan , 
                    nan , nan , nan , nan , nan , 
                    nan 

 TPCTrack.clusterZ[16] = -12.254172 , -12.055928 , -12.090313 , -12.048982 , -12.041853 , 
                    -12.036312 , -11.958266 , -12.104868 , nan , nan , 
                    nan , nan , nan , nan , nan , 
                    nan 

 TPCTrack.clusterE[16] = 78.000000 , 233.000000 , 297.000000 , 1283.000000 , 273.000000 , 
                    176.000000 , 366.000000 , 767.000000 , nan , nan , 
                    nan , nan , nan , nan , nan , 
                    nan 

 TPCTrack.clusterSizePhi[16] = 6.000000 , 6.000000 , 8.000000 , 8.000000 , 8.000000 , 
                    8.000000 , 8.000000 , 8.000000 , nan , nan , 
                    nan , nan , nan , nan , nan , 
                    nan 

 TPCTrack.clusterResidualPhi[16] = -0.195077 , 0.041198 , -0.042488 , 0.056664 , -0.014539 , 
                    -0.023344 , 0.017743 , -0.003741 , nan , nan , 
                    nan , nan , nan , nan , nan , 
                    nan 

 TPCTrack.clusterProjectionPhi[16] = -2.897244 , -2.898538 , -2.897788 , -2.898675 , -2.898759 , 
                    -2.899053 , -2.899568 , -2.899732 , nan , nan , 
                    nan , nan , nan , nan , nan , 
                    nan 

 TPCTrack.clusterResidualZ[16] = -0.187522 , 0.015675 , -0.046137 , 0.004545 , 0.007258 , 
                    0.008670 , 0.112733 , -0.131991 , nan , nan , 
                    nan , nan , nan , nan , nan , 
                    nan 

```

For example, the last cluster on `TPCTrack.clusterlayer == 7` has `TPCTrack.clusterid == 2`. Its raw data can be found in the printout below with `Clusters.clusterID == 2`

### `TpcPrototypeUnpacker.root`
```
root
root [0] gSystem->Load("libtpc2019")
(int) 0
root [1] TFile::Open("data/tpc_beam/tpc_beam_00000300-0000.evt_TpcPrototypeUnpacker.root")
(TFile *) 0x2ea1530
root [2] eventT->Scan("run:event")
************************************
*    Row   *       run *     event *
************************************
*        0 *       300 *         2 *
*        1 *       300 *         3 *
*        2 *       300 *         4 *
*        3 *       300 *         5 *
*        4 *       300 *         6 *
*        5 *       300 *         7 *
*        6 *       300 *         8 *
*        7 *       300 *         9 *
*        8 *       300 *        10 *
************************************
(long long) 9
root [3] eventT->Show(0)
======> EVENT:0
root [3] eventT->Show(0)
======> EVENT:0
...
 run             = 300
 event           = 2
 bx_counter      = 0
...
 nClusters       = 45
 Clusters        = 45
...
 Clusters.clusterID = 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19
...
 Clusters.min_sample = 58, 63, 58, 63, 63, 63, 63, 59, 60, 33, 63, 59, 59, 63, 18, 17, 59, 33, 17, 59
 Clusters.max_sample = 78, 81, 77, 81, 81, 81, 81, 76, 78, 50, 81, 75, 76, 80, 34, 34, 76, 50, 34, 76
 Clusters.min_pad_azimuth = 58, 63, 57, 63, 63, 63, 63, 57, 61, 63, 63, 57, 57, 63, 52, 52, 57, 63, 52, 57
 Clusters.max_pad_azimuth = 61, 66, 60, 66, 66, 67, 66, 60, 64, 66, 65, 60, 60, 66, 55, 55, 60, 66, 55, 60
 Clusters.peak   = 1283.24, 894.788, 767.042, 756.704, 696.924, 630.98, 479.202, 401.187, 399.378, 384.62, 379.734, 373.333, 366.723, 342.931, 336.942, 330.166, 328.957, 327.31, 306.031, 301.61
 Clusters.peak_sample = 7.42221, 6.57036, 7.29041, 6.55644, 6.59162, 6.51741, 6.56271, 6.55497, 7.11111, 6.40918, 6.56525, 6.59348, 6.63616, 6.5482, 5.98238, 6.43825, 6.62976, 6.39603, 6.5002, 6.65981
 Clusters.pedstal = 9.38965, -18.5853, 12.243, -20.6182, -16.7551, -15.8788, -14.6245, 9.4838, -29.6839, -16.0463, -5.99275, 11.293, 13.4528, -16.9394, 6.62837, 4.74402, 18.641, -13.7772, 5.52035, 17.7872
 Clusters.pad_azimuth_peaks = (map<int,double>*)0x440dc68, (map<int,double>*)0x440de28, (map<int,double>*)0x440dfe8, (map<int,double>*)0x440e1a8, (map<int,double>*)0x4424ca8, (map<int,double>*)0x4424e68, (map<int,double>*)0x4425028, (map<int,double>*)0x44251e8, (map<int,double>*)0x44253a8, (map<int,double>*)0x4425568, (map<int,double>*)0x4425728, (map<int,double>*)0x44258e8, (map<int,double>*)0x4425aa8, (map<int,double>*)0x280fb68, (map<int,double>*)0x280fd28, (map<int,double>*)0x280fee8, (map<int,double>*)0x28100a8, (map<int,double>*)0x2810268, (map<int,double>*)0x2810428, (map<int,double>*)0x28105e8
 Clusters.avg_pad_radial = 3, 3, 7, 1, 2, 0, 7, 9, 14, 5, 8, 11, 6, 6, 5, 15, 12, 4, 13, 13
 Clusters.avg_pad_azimuth = 59.1963, 64.5401, 58.6072, 64.6318, 64.5517, 64.9555, 64.2343, 58.5566, 62.5727, 64.3667, 64.1466, 58.6036, 58.7559, 64.2413, 53.5767, 53.7133, 58.4588, 64.4197, 53.611, 58.3406
 Clusters.size_pad_radial = 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 Clusters.size_pad_azimuth = 4, 4, 4, 4, 4, 5, 4, 4, 4, 4, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4
 Clusters.avg_pos_x = -43.0585, -42.8137, -47.9388, -40.3975, -41.6071, -39.1774, -47.654, -50.3686, -56.2011, -45.2345, -48.8652, -52.7935, -46.7181, -46.4472, -45.7328, -57.9209, -54.0151, -44.0256, -55.4874, -55.2354
 Clusters.avg_pos_y = -10.7288, -11.6674, -11.8221, -11.0252, -11.3407, -10.748, -12.9224, -12.4103, -14.8308, -12.2926, -13.232, -13.0185, -11.5513, -12.5966, -10.2847, -13.0597, -13.2858, -11.9743, -12.4866, -13.5577
 Clusters.avg_pos_z = -12.049, -10.2902, -12.1049, -10.2961, -10.2812, -10.3126, -10.2934, -11.9927, -11.3329, -23.0785, -10.2923, -11.9764, -11.9583, -10.2996, -29.6195, -29.8502, -11.961, -23.0841, -29.8239, -11.9482
 Clusters.delta_azimuth_bin = 0.00409062, 0.00409062, 0.00409062, 0.00409062, 0.00409062, 0.00409062, 0.00409062, 0.00409062, 0.00409062, 0.00409062, 0.00409062, 0.00409062, 0.00409062, 0.00409062, 0.00409062, 0.00409062, 0.00409062, 0.00409062, 0.00409062, 0.00409062
 Clusters.delta_z = 0.424, 0.424, 0.424, 0.424, 0.424, 0.424, 0.424, 0.424, 0.424, 0.424, 0.424, 0.424, 0.424, 0.424, 0.424, 0.424, 0.424, 0.424, 0.424, 0.424
```

# 2. Improve cluster descriptions in `TpcPrototypeUnpacker.root`

As shown in the `TpcPrototypeUnpacker.root` in the last section
* Pad's x/y indexes are renamed pad's azimuth and z indexes to reflect the setting in test beam, such as `Clusters.avg_pad_azimuth` and `Clusters.avg_pad_radial`
* For each cluster, the boundary for the 2D pad-ADC bins are described with `Clusters.min_pad_azimuth` - `max_pad_azimuth` and Clusters.min_sample` - `max_sample`
* The pad-ADC bin sizes, `Clusters.delta_azimuth_bin` and `Clusters.delta_z`, can be used to convert `TPCTrack.clusterResidualPhi` and `TPCTrack.clusterResidualZ` into the residual in units of the pad-ADChits grid

