### PR TITLE
genfit default lib install moved to lib64

### DIFF
--- a/offline/packages/tpc2019/Makefile.am
+++ b/offline/packages/tpc2019/Makefile.am
@@ -13,12 +13,13 @@ AM_CXXFLAGS = \
 AM_CPPFLAGS = \
   -I$(includedir) \
   -I$(OFFLINE_MAIN)/include \
-  -I`root-config --incdir` \
-  -I$(OFFLINE_MAIN)/include/eigen3
+  -I$(OFFLINE_MAIN)/include/eigen3 \
+  -I`root-config --incdir`
 
 AM_LDFLAGS = \
   -L$(libdir) \
   -L$(OFFLINE_MAIN)/lib \
+  -L$(OFFLINE_MAIN)/lib64 \
   `root-config --libs`
 
 pkginclude_HEADERS = \


### PR DESCRIPTION
We have libgenfit2 now in either $OFFLINE_MAIN/lib or $OFFLINE_MAIN/lib64 depending on the build. So we need to check both locations for libraries