### PR TITLE
remove link against obsolete calo_util lib

### DIFF
--- a/offline/packages/Prototype2/Makefile.am
+++ b/offline/packages/Prototype2/Makefile.am
@@ -61,7 +61,6 @@ libPrototype2_la_LIBADD = \
   -lSubsysReco \
   -lphool \
   -lfun4all \
-  -lcalo_util \
   -lphparameter
 
 BUILT_SOURCES = \

--- a/offline/packages/Prototype3/Makefile.am
+++ b/offline/packages/Prototype3/Makefile.am
@@ -61,7 +61,6 @@ libPrototype3_la_LIBADD = \
   libPrototype3_io.la \
   -lSubsysReco \
   -lfun4all \
-  -lcalo_util \
   -lphparameter
 
 # Rule for generating CINT dictionaries from class headers.

--- a/offline/packages/Prototype4/Makefile.am
+++ b/offline/packages/Prototype4/Makefile.am
@@ -61,7 +61,6 @@ libPrototype4_la_LIBADD = \
   libPrototype4_io.la \
   -lSubsysReco \
   -lfun4all \
-  -lcalo_util \
   -lphparameter
 
 # Rule for generating CINT dictionaries from class headers.


### PR DESCRIPTION
This PR removes the linking against libcalo_util which is not build anymore