### PR TITLE
adjust flags for clang 11

### DIFF
--- a/offline/packages/Prototype2/configure.ac
+++ b/offline/packages/Prototype2/configure.ac
@@ -5,12 +5,14 @@ AM_INIT_AUTOMAKE
 AC_PROG_CXX(CC g++)
 LT_INIT([disable-static])
 
-dnl   no point in suppressing warnings people should
-dnl   at least see them, so here we go for g++: -Wall
-dnl   make warnings fatal errors: -Werror
-if test $ac_cv_prog_gxx = yes; then
-   CXXFLAGS="$CXXFLAGS -Wall -Werror"
-fi
+case $CXX in
+ clang++)
+  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-return-stack-address"
+ ;;
+ g++)
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
+ ;;
+esac
 
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)

--- a/offline/packages/Prototype3/configure.ac
+++ b/offline/packages/Prototype3/configure.ac
@@ -8,17 +8,17 @@ LT_INIT([disable-static])
 case $CXX in
   clang++)
 # boost statistics
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-deprecated-declarations"
-  ;;
-esac
-
-if test $ac_cv_prog_gxx = yes; then
+  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-deprecated-declarations -Wno-return-stack-address"
+ ;;
+ g++)
   if test `g++ -dumpversion | gawk '{print $1>=8.0?"1":"0"}'` = 1; then
    CXXFLAGS="$CXXFLAGS -Wall -Wno-deprecated-declarations -Werror"
   else
    CXXFLAGS="$CXXFLAGS -Wall -Werror"
   fi
-fi
+  ;;
+esac
+
 
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)

--- a/offline/packages/Prototype4/configure.ac
+++ b/offline/packages/Prototype4/configure.ac
@@ -6,20 +6,18 @@ AC_PROG_CXX(g++)
 LT_INIT([disable-static])
 
 case $CXX in
- clang++)
-dnl boost accumulators
- CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-deprecated-declarations"
+  clang++)
+# boost statistics
+  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-deprecated-declarations -Wno-return-stack-address"
  ;;
-esac
-
-dnl test for gcc 8.3
-if test $ac_cv_prog_gxx = yes; then
+ g++)
   if test `g++ -dumpversion | gawk '{print $1>=8.0?"1":"0"}'` = 1; then
    CXXFLAGS="$CXXFLAGS -Wall -Wno-deprecated-declarations -Werror"
   else
    CXXFLAGS="$CXXFLAGS -Wall -Werror"
   fi
-fi
+  ;;
+esac
 
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)

--- a/simulation/g4simulation/g4caloprototype/configure.ac
+++ b/simulation/g4simulation/g4caloprototype/configure.ac
@@ -7,7 +7,7 @@ LT_INIT([disable-static])
 
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-undefined-var-template -Wno-unused-private-field"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-undefined-var-template -Wno-unused-private-field -Wno-c11-extensions -Wno-return-stack-address"
  ;;
  g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"


### PR DESCRIPTION
This PR adds compiler flags to suppress the warnings of clang 11