### PR TITLE
Class def override

### DIFF
--- a/offline/packages/MvtxPrototype1/configure.ac
+++ b/offline/packages/MvtxPrototype1/configure.ac
@@ -12,7 +12,7 @@ if test $ac_cv_prog_gxx = yes; then
    CXXFLAGS="$CXXFLAGS -Wall"
 fi
 
-CINTDEFS=" -noIncludePaths  -inlineInputHeader "
+CINTDEFS=" -noIncludePaths  -inlineInputHeader -Wno-inconsistent-missing-override "
 AC_SUBST(CINTDEFS)
 
 AC_CONFIG_FILES([Makefile])

--- a/offline/packages/Prototype2/RawTower_Prototype2.h
+++ b/offline/packages/Prototype2/RawTower_Prototype2.h
@@ -68,7 +68,7 @@ class RawTower_Prototype2 : public RawTower
   signal_type signal_samples[NSAMPLES];  // Low Gain
   int HBD_channel;
 
-  ClassDef(RawTower_Prototype2, 3)
+  ClassDefOverride(RawTower_Prototype2, 3)
 };
 
 #endif

--- a/offline/packages/Prototype2/RawTower_Temperature.h
+++ b/offline/packages/Prototype2/RawTower_Temperature.h
@@ -77,7 +77,7 @@ class RawTower_Temperature : public RawTower
   std::vector<time_t> times;
   std::vector<float> temperatures;
 
-  ClassDef(RawTower_Temperature, 1)
+  ClassDefOverride(RawTower_Temperature, 1)
 };
 
 #endif

--- a/offline/packages/Prototype2/configure.ac
+++ b/offline/packages/Prototype2/configure.ac
@@ -14,7 +14,7 @@ case $CXX in
  ;;
 esac
 
-CINTDEFS=" -noIncludePaths  -inlineInputHeader "
+CINTDEFS=" -noIncludePaths  -inlineInputHeader -Wno-inconsistent-missing-override "
 AC_SUBST(CINTDEFS)
 
 AC_CONFIG_FILES([Makefile])

--- a/offline/packages/Prototype3/RawTower_Prototype3.h
+++ b/offline/packages/Prototype3/RawTower_Prototype3.h
@@ -69,7 +69,7 @@ class RawTower_Prototype3 : public RawTower
   signal_type signal_samples[NSAMPLES];  // Low Gain
   int HBD_channel;
 
-  ClassDef(RawTower_Prototype3, 3)
+  ClassDefOverride(RawTower_Prototype3, 3)
 };
 
 #endif

--- a/offline/packages/Prototype3/RawTower_Temperature.h
+++ b/offline/packages/Prototype3/RawTower_Temperature.h
@@ -77,7 +77,7 @@ class RawTower_Temperature : public RawTower
   std::vector<time_t> times;
   std::vector<float> temperatures;
 
-  ClassDef(RawTower_Temperature, 1)
+  ClassDefOverride(RawTower_Temperature, 1)
 };
 
 #endif

--- a/offline/packages/Prototype3/configure.ac
+++ b/offline/packages/Prototype3/configure.ac
@@ -20,7 +20,7 @@ case $CXX in
 esac
 
 
-CINTDEFS=" -noIncludePaths  -inlineInputHeader "
+CINTDEFS=" -noIncludePaths  -inlineInputHeader -Wno-inconsistent-missing-override "
 AC_SUBST(CINTDEFS)
 
 AC_CONFIG_FILES([Makefile])

--- a/offline/packages/Prototype4/RawTower_Prototype4.h
+++ b/offline/packages/Prototype4/RawTower_Prototype4.h
@@ -69,7 +69,7 @@ class RawTower_Prototype4 : public RawTower
   signal_type signal_samples[NSAMPLES];  // Low Gain
   int HBD_channel;
 
-  ClassDef(RawTower_Prototype4, 3)
+  ClassDefOverride(RawTower_Prototype4, 3)
 };
 
 #endif

--- a/offline/packages/Prototype4/RawTower_Temperature.h
+++ b/offline/packages/Prototype4/RawTower_Temperature.h
@@ -76,7 +76,7 @@ class RawTower_Temperature : public RawTower
   std::vector<time_t> times;
   std::vector<float> temperatures;
 
-  ClassDef(RawTower_Temperature, 1)
+  ClassDefOverride(RawTower_Temperature, 1)
 };
 
 #endif

--- a/offline/packages/Prototype4/configure.ac
+++ b/offline/packages/Prototype4/configure.ac
@@ -19,7 +19,7 @@ case $CXX in
   ;;
 esac
 
-CINTDEFS=" -noIncludePaths  -inlineInputHeader "
+CINTDEFS=" -noIncludePaths  -inlineInputHeader -Wno-inconsistent-missing-override "
 AC_SUBST(CINTDEFS)
 
 AC_CONFIG_FILES([Makefile])

--- a/offline/packages/tpc2019/TpcPrototypeCluster.h
+++ b/offline/packages/tpc2019/TpcPrototypeCluster.h
@@ -321,7 +321,7 @@ class TpcPrototypeCluster : public TrkrCluster
   //! z size per ADC sample bin
   double delta_z;
 
-  ClassDef(TpcPrototypeCluster, 1)
+  ClassDefOverride(TpcPrototypeCluster, 1)
 };
 
 #endif  //TRACKBASE_TRKRCLUSTERV1_H

--- a/offline/packages/tpc2019/TpcPrototypeTrack.h
+++ b/offline/packages/tpc2019/TpcPrototypeTrack.h
@@ -67,7 +67,7 @@ class TpcPrototypeTrack : public PHObject
   //
   //    float residualIsolated;
   //
-  //    ClassDef(TpcPrototypeTrack::Cluster, 1);
+  //    ClassDefOverride(TpcPrototypeTrack::Cluster, 1);
   //  };
 
   //  Cluster clusters[nLayer];
@@ -83,7 +83,7 @@ class TpcPrototypeTrack : public PHObject
   float clusterProjectionPhi[nLayer];
   float clusterResidualZ[nLayer];
 
-  ClassDef(TpcPrototypeTrack, 5);
+  ClassDefOverride(TpcPrototypeTrack, 5);
 };
 
 #endif /* TPCPROTOTYPETRACK_H_ */

--- a/offline/packages/tpc2019/TpcPrototypeUnpacker.h
+++ b/offline/packages/tpc2019/TpcPrototypeUnpacker.h
@@ -91,7 +91,7 @@ class TpcPrototypeUnpacker : public SubsysReco
     {
     }
 
-    ClassDef(TpcPrototypeUnpacker::EventHeader, 1)
+    ClassDefOverride(TpcPrototypeUnpacker::EventHeader, 1)
   };
 
   //! buffer for full event data
@@ -209,7 +209,7 @@ class TpcPrototypeUnpacker : public SubsysReco
     //! z size per ADC sample bin
     double delta_z;
 
-    ClassDef(TpcPrototypeUnpacker::ClusterData, 5);
+    ClassDefOverride(TpcPrototypeUnpacker::ClusterData, 5);
   };
 
   //! simple channel header class for ROOT file IO
@@ -253,7 +253,7 @@ class TpcPrototypeUnpacker : public SubsysReco
     {
     }
 
-    ClassDef(TpcPrototypeUnpacker::ChannelHeader, 1)
+    ClassDefOverride(TpcPrototypeUnpacker::ChannelHeader, 1)
   };
 
  private:

--- a/offline/packages/tpc2019/configure.ac
+++ b/offline/packages/tpc2019/configure.ac
@@ -12,7 +12,7 @@ if test $ac_cv_prog_gxx = yes; then
    CXXFLAGS="$CXXFLAGS -Wall -Werror"
 fi
 
-CINTDEFS=" -noIncludePaths  -inlineInputHeader "
+CINTDEFS=" -noIncludePaths  -inlineInputHeader -Wno-inconsistent-missing-override "
 AC_SUBST(CINTDEFS)
 
 AC_CONFIG_FILES([Makefile])


### PR DESCRIPTION
This PR replaces the old ClassDef by ClassDefOverride so we can use the override keyword. Until all is sorted out rootcling will complain and it needs  -Wno-inconsistent-missing-override added to the CINTDEFS (not the compiler flags which makes this a lot easier). Let's see what jenkins says for the coresoftware PR