### PR TITLE
remove unneccessary dep on libphg4gdml

### DIFF
--- a/simulation/g4simulation/g4caloprototype/Makefile.am
+++ b/simulation/g4simulation/g4caloprototype/Makefile.am
@@ -25,7 +25,6 @@ libg4caloprototype_la_LIBADD = \
   -lcalo_io \
   -lg4testbench \
   -lg4detectors \
-  -lphg4gdml \
   -lphool  \
   -lSubsysReco
 


### PR DESCRIPTION
Small cleanup - g4gdml need to be re-implemented for G4 11.0.0, this prevents the prototypes from killing test builds