### PR TITLE
warning suppressions for clang 14

### DIFF
--- a/offline/packages/Prototype2/configure.ac
+++ b/offline/packages/Prototype2/configure.ac
@@ -5,12 +5,11 @@ AM_INIT_AUTOMAKE
 AC_PROG_CXX(CC g++)
 LT_INIT([disable-static])
 
+CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-unused-parameter"
+
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-unused-parameter"
- ;;
- *g++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-unused-parameter"
+  CXXFLAGS="$CXXFLAGS -Wno-bitwise-instead-of-logical -Wno-unknown-warning-option"
  ;;
 esac
 

--- a/offline/packages/Prototype4/configure.ac
+++ b/offline/packages/Prototype4/configure.ac
@@ -8,7 +8,7 @@ LT_INIT([disable-static])
 case $CXX in
   clang++)
 # boost statistics
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-deprecated-declarations -Wno-unused-parameter"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-deprecated-declarations -Wno-unused-parameter -Wno-bitwise-instead-of-logical -Wno-unknown-warning-option"
  ;;
  *g++)
   if test `g++ -dumpversion | gawk '{print $1>=8.0?"1":"0"}'` = 1; then


### PR DESCRIPTION
This PR adds the flags needed to compile with clang 11 and clang 14