### PR TITLE
fix clang 14 compilation

### DIFF
--- a/offline/packages/Prototype2/Makefile.am
+++ b/offline/packages/Prototype2/Makefile.am
@@ -10,7 +10,7 @@ lib_LTLIBRARIES = \
 AM_CPPFLAGS = \
   -I$(includedir) \
   -I$(OFFLINE_MAIN)/include \
-  -I`root-config --incdir`
+  -isystem`root-config --incdir`
 
 AM_LDFLAGS = \
   -L$(libdir) \

--- a/offline/packages/Prototype3/Makefile.am
+++ b/offline/packages/Prototype3/Makefile.am
@@ -10,7 +10,7 @@ lib_LTLIBRARIES = \
 AM_CPPFLAGS = \
   -I$(includedir) \
   -I$(OFFLINE_MAIN)/include \
-  -I`root-config --incdir`
+  -isystem`root-config --incdir`
 
 AM_LDFLAGS = \
   -L$(libdir) \

--- a/offline/packages/Prototype4/Makefile.am
+++ b/offline/packages/Prototype4/Makefile.am
@@ -10,7 +10,7 @@ lib_LTLIBRARIES = \
 AM_CPPFLAGS = \
   -I$(includedir) \
   -I$(OFFLINE_MAIN)/include \
-  -I`root-config --incdir`
+  -isystem`root-config --incdir`
 
 AM_LDFLAGS = \
   -L$(libdir) \

--- a/simulation/g4simulation/g4caloprototype/Makefile.am
+++ b/simulation/g4simulation/g4caloprototype/Makefile.am
@@ -9,7 +9,7 @@ AM_CXXFLAGS = `geant4-config --cflags | sed s/-Woverloaded-virtual// | sed s/-W\
 AM_CPPFLAGS = \
     -I$(includedir) \
     -I$(OFFLINE_MAIN)/include \
-    -I$(ROOTSYS)/include \
+    -isystem$(ROOTSYS)/include \
     -I$(G4_MAIN)/include
 
 # set in configure.in to check if gcc version >= 4.8


### PR DESCRIPTION
This PR replaces -I$(ROOTSYS)/include by -isystem$(ROOTSYS)/include so root headers are not checked